### PR TITLE
Some fixes for action behavior

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,8 +84,6 @@ class Degit extends EventEmitter {
     }
 
     async clone(dest) {
-        // Grab a directive file, if it exists then get rid of it
-        const directives = this._getDirectives(dest);
         this._checkDirIsEmpty(dest);
 
         const repo = this.repo;
@@ -158,9 +156,9 @@ class Degit extends EventEmitter {
             dest,
         });
 
-        const newDirectives = directives || this._getDirectives(dest);
-        if (newDirectives) {
-            for (const d of newDirectives) {
+        const directives = this._getDirectives(dest);
+        if (directives) {
+            for (const d of directives) {
                 // TODO, can this be a loop with an index to pass for better error messages?
                 await this.directiveActions[d.action](dir, dest, d);
             }

--- a/src/index.js
+++ b/src/index.js
@@ -5,321 +5,391 @@ import tar from 'tar';
 import EventEmitter from 'events';
 import chalk from 'chalk';
 import { rimrafSync } from 'sander';
-import { DegitError, exec, fetch, mkdirp, tryRequire, stashFiles, unstashFiles, degitConfigName } from './utils';
+import {
+    DegitError,
+    exec,
+    fetch,
+    mkdirp,
+    tryRequire,
+    stashFiles,
+    unstashFiles,
+    degitConfigName,
+} from './utils';
 
 const base = path.join(homeOrTmp, '.degit');
 
 export default function degit(src, opts) {
-	return new Degit(src, opts);
+    return new Degit(src, opts);
 }
 
 class Degit extends EventEmitter {
-	constructor(src, opts = {}) {
-		super();
+    constructor(src, opts = {}) {
+        super();
 
-		this.src = src;
-		this.cache = opts.cache;
-		this.force = opts.force;
-		this.verbose = opts.verbose;
+        this.src = src;
+        this.cache = opts.cache;
+        this.force = opts.force;
+        this.verbose = opts.verbose;
 
-		this.repo = parse(src);
+        this.repo = parse(src);
 
-		this.directiveActions = {
-			clone: async (dest, action) => {
-				const opts = Object.assign({force: true}, {cache: action.cache, verbose: action.verbose});
-				const d = degit(action.src, opts);
+        this._hasStashed = false;
 
-				d.on('info', event => {
-					console.error(chalk.cyan(`> ${event.message.replace('options.', '--')}`));
-				});
+        this.directiveActions = {
+            clone: async (dir, dest, action) => {
+                if (this._hasStashed === false) {
+                    stashFiles(dir, dest);
+                    this._hasStashed = true;
+                }
+                const opts = Object.assign(
+                    { force: true },
+                    { cache: action.cache, verbose: action.verbose }
+                );
+                const d = degit(action.src, opts);
 
-				d.on('warn', event => {
-					console.error(chalk.magenta(`! ${event.message.replace('options.', '--')}`));
-				});
+                d.on('info', event => {
+                    console.error(
+                        chalk.cyan(
+                            `> ${event.message.replace('options.', '--')}`
+                        )
+                    );
+                });
 
-				await d.clone(dest)
-					.catch(err => {
-						console.error(chalk.red(`! ${err.message}`));
-						process.exit(1);
-					});
-			},
-			remove: this.remove.bind(this)
-		};
-	}
+                d.on('warn', event => {
+                    console.error(
+                        chalk.magenta(
+                            `! ${event.message.replace('options.', '--')}`
+                        )
+                    );
+                });
 
-	async clone(dest) {
-		this._checkDirIsEmpty(dest);
+                await d.clone(dest).catch(err => {
+                    console.error(chalk.red(`! ${err.message}`));
+                    process.exit(1);
+                });
+            },
+            remove: this.remove.bind(this),
+        };
+    }
 
-		const repo = this.repo;
+    _getDirectives(dest) {
+        const directivesPath = path.resolve(dest, degitConfigName);
+        const directives =
+            tryRequire(directivesPath, { clearCache: true }) || false;
+        if (directives) {
+            fs.unlinkSync(directivesPath);
+        }
 
-		const dir = path.join(base, repo.site, repo.user, repo.name);
-		const cached = tryRequire(path.join(dir, 'map.json')) || {};
+        return directives;
+    }
 
-		const hash = this.cache ?
-			this._getHashFromCache(repo, cached) :
-			await this._getHash(repo, cached);
+    async clone(dest) {
+        // Grab a directive file, if it exists then get rid of it
+        const directives = this._getDirectives(dest);
+        this._checkDirIsEmpty(dest);
 
-		if (!hash) {
-			// TODO 'did you mean...?'
-			throw new DegitError(`could not find commit hash for ${repo.ref}`, {
-				code: 'MISSING_REF',
-				ref: repo.ref
-			});
-		}
+        const repo = this.repo;
 
-		const file = `${dir}/${hash}.tar.gz`;
-		const url = (
-			repo.site === 'gitlab' ? `${repo.url}/repository/archive.tar.gz?ref=${hash}` :
-			repo.site === 'bitbucket' ? `${repo.url}/get/${hash}.tar.gz` :
-			`${repo.url}/archive/${hash}.tar.gz`
-		);
+        const dir = path.join(base, repo.site, repo.user, repo.name);
+        const cached = tryRequire(path.join(dir, 'map.json')) || {};
 
-		try {
-			if (!this.cache) {
-				try {
-					fs.statSync(file);
-					this._verbose({
-						code: 'FILE_EXISTS',
-						message: `${file} already exists locally`
-					});
-				} catch (err) {
-					mkdirp(path.dirname(file));
-					this._verbose({
-						code: 'DOWNLOADING',
-						message: `downloading ${url} to ${file}`
-					});
+        const hash = this.cache
+            ? this._getHashFromCache(repo, cached)
+            : await this._getHash(repo, cached);
 
-					await fetch(url, file);
-				}
-			}
-		} catch (err) {
-			throw new DegitError(`could not download ${url}`, {
-				code: 'COULD_NOT_DOWNLOAD',
-				url,
-				original: err
-			});
-		}
+        if (!hash) {
+            // TODO 'did you mean...?'
+            throw new DegitError(`could not find commit hash for ${repo.ref}`, {
+                code: 'MISSING_REF',
+                ref: repo.ref,
+            });
+        }
 
-		updateCache(dir, repo, hash, cached);
+        const file = `${dir}/${hash}.tar.gz`;
+        const url =
+            repo.site === 'gitlab'
+                ? `${repo.url}/repository/archive.tar.gz?ref=${hash}`
+                : repo.site === 'bitbucket'
+                    ? `${repo.url}/get/${hash}.tar.gz`
+                    : `${repo.url}/archive/${hash}.tar.gz`;
 
-		this._verbose({
-			code: 'EXTRACTING',
-			message: `extracting ${file} to ${dest}`
-		});
+        try {
+            if (!this.cache) {
+                try {
+                    fs.statSync(file);
+                    this._verbose({
+                        code: 'FILE_EXISTS',
+                        message: `${file} already exists locally`,
+                    });
+                } catch (err) {
+                    mkdirp(path.dirname(file));
+                    this._verbose({
+                        code: 'DOWNLOADING',
+                        message: `downloading ${url} to ${file}`,
+                    });
 
-		mkdirp(dest);
-		await untar(file, dest);
+                    await fetch(url, file);
+                }
+            }
+        } catch (err) {
+            throw new DegitError(`could not download ${url}`, {
+                code: 'COULD_NOT_DOWNLOAD',
+                url,
+                original: err,
+            });
+        }
 
-		this._info({
-			code: 'SUCCESS',
-			message: `cloned ${chalk.bold(repo.user + '/' + repo.name)}#${chalk.bold(repo.ref)}${dest !== '.' ? ` to ${dest}` : ''}`,
-			repo,
-			dest
-		});
+        updateCache(dir, repo, hash, cached);
 
-		const directives = tryRequire(path.resolve(dest, degitConfigName), {clearCache: true}) || false;
-		if (directives) {
-			stashFiles(dir, dest);
-			for (const d of directives) {
-				// TODO, can this be a loop with an index to pass for better error messages?
-				await this.directiveActions[d.action](dest, d);
-			}
-			unstashFiles(dir, dest);
-		}
-	}
+        this._verbose({
+            code: 'EXTRACTING',
+            message: `extracting ${file} to ${dest}`,
+        });
 
-	remove(dest, action) {
-		let files = action.files;
-		if (!Array.isArray(files)) {
-			files = [files];
-		}
-		const removedFiles = files.map(file => {
-			const filePath = path.resolve(dest, file);
-			if (fs.existsSync(filePath)) {
-				const isDir = fs.lstatSync(filePath).isDirectory();
-				if (isDir) {
-					rimrafSync(filePath);
-					return file + '/';
-				} else {
-					fs.unlinkSync(filePath);
-					return file;
-				}
-			} else {
-				this._warn({
-					code: 'FILE_DOES_NOT_EXIST',
-					message: `action wants to remove ${chalk.bold(file)} but it does not exist`
-				});
-				return null;
-			}
-		}).filter(d => d);
+        mkdirp(dest);
+        await untar(file, dest);
 
-		this._info({
-			code: 'REMOVED',
-			message: `removed: ${chalk.bold(removedFiles.map(d => chalk.bold(d)).join(', '))}`
-		});
-	}
+        this._info({
+            code: 'SUCCESS',
+            message: `cloned ${chalk.bold(
+                repo.user + '/' + repo.name
+            )}#${chalk.bold(repo.ref)}${dest !== '.' ? ` to ${dest}` : ''}`,
+            repo,
+            dest,
+        });
 
-	_checkDirIsEmpty(dir) {
-		try {
-			const files = fs.readdirSync(dir);
-			if (files.length > 0) {
-				if (this.force) {
-					this._info({
-						code: 'DEST_NOT_EMPTY',
-						message: `destination directory is not empty. Using options.force, continuing`
-					});
-				} else {
-					throw new DegitError(`destination directory is not empty, aborting. Use options.force to override`, {
-						code: 'DEST_NOT_EMPTY'
-					});
-				}
-			} else {
-				this._verbose({
-					code: 'DEST_IS_EMPTY',
-					message: `destination directory is empty`
-				});
-			}
-		} catch (err) {
-			if (err.code !== 'ENOENT') throw err;
-		}
-	}
+        const newDirectives = directives || this._getDirectives(dest);
+        if (newDirectives) {
+            for (const d of newDirectives) {
+                // TODO, can this be a loop with an index to pass for better error messages?
+                await this.directiveActions[d.action](dir, dest, d);
+            }
+            if (this._hasStashed === true) {
+                unstashFiles(dir, dest);
+            }
+        }
+    }
 
-	_info(info) {
-		this.emit('info', info);
-	}
+    remove(dir, dest, action) {
+        let files = action.files;
+        if (!Array.isArray(files)) {
+            files = [files];
+        }
+        const removedFiles = files
+            .map(file => {
+                const filePath = path.resolve(dest, file);
+                if (fs.existsSync(filePath)) {
+                    const isDir = fs.lstatSync(filePath).isDirectory();
+                    if (isDir) {
+                        rimrafSync(filePath);
+                        return file + '/';
+                    } else {
+                        fs.unlinkSync(filePath);
+                        return file;
+                    }
+                } else {
+                    this._warn({
+                        code: 'FILE_DOES_NOT_EXIST',
+                        message: `action wants to remove ${chalk.bold(
+                            file
+                        )} but it does not exist`,
+                    });
+                    return null;
+                }
+            })
+            .filter(d => d);
 
-	_warn(info) {
-		this.emit('warn', info);
-	}
+        if (removedFiles.length > 0) {
+            this._info({
+                code: 'REMOVED',
+                message: `removed: ${chalk.bold(
+                    removedFiles.map(d => chalk.bold(d)).join(', ')
+                )}`,
+            });
+        }
+    }
 
-	_verbose(info) {
-		if (this.verbose) this._info(info);
-	}
+    _checkDirIsEmpty(dir) {
+        try {
+            const files = fs.readdirSync(dir);
+            if (files.length > 0) {
+                if (this.force) {
+                    this._info({
+                        code: 'DEST_NOT_EMPTY',
+                        message: `destination directory is not empty. Using options.force, continuing`,
+                    });
+                } else {
+                    throw new DegitError(
+                        `destination directory is not empty, aborting. Use options.force to override`,
+                        {
+                            code: 'DEST_NOT_EMPTY',
+                        }
+                    );
+                }
+            } else {
+                this._verbose({
+                    code: 'DEST_IS_EMPTY',
+                    message: `destination directory is empty`,
+                });
+            }
+        } catch (err) {
+            if (err.code !== 'ENOENT') throw err;
+        }
+    }
 
-	async _getHash(repo, cached) {
-		try {
-			const refs = await fetchRefs(repo);
-			return this._selectRef(refs, repo.ref);
-		} catch (err) {
-			return this._getHashFromCache(repo, cached);
-		}
-	}
+    _info(info) {
+        this.emit('info', info);
+    }
 
-	_getHashFromCache(repo, cached) {
-		if (repo.ref in cached) {
-			const hash = cached[repo.ref];
-			this._info({
-				code: 'USING_CACHE',
-				message: `using cached commit hash ${hash}`
-			});
-			return hash;
-		}
-	}
+    _warn(info) {
+        this.emit('warn', info);
+    }
 
-	_selectRef(refs, selector) {
-		for (const ref of refs) {
-			if (ref.name === selector) {
-				this._verbose({
-					code: 'FOUND_MATCH',
-					message: `found matching commit hash: ${ref.hash}`
-				});
-				return ref.hash;
-			}
-		}
+    _verbose(info) {
+        if (this.verbose) this._info(info);
+    }
 
-		if (selector.length < 8) return null;
+    async _getHash(repo, cached) {
+        try {
+            const refs = await fetchRefs(repo);
+            return this._selectRef(refs, repo.ref);
+        } catch (err) {
+            return this._getHashFromCache(repo, cached);
+        }
+    }
 
-		for (const ref of refs) {
-			if (ref.hash.startsWith(selector)) return ref.hash;
-		}
-	}
+    _getHashFromCache(repo, cached) {
+        if (repo.ref in cached) {
+            const hash = cached[repo.ref];
+            this._info({
+                code: 'USING_CACHE',
+                message: `using cached commit hash ${hash}`,
+            });
+            return hash;
+        }
+    }
+
+    _selectRef(refs, selector) {
+        for (const ref of refs) {
+            if (ref.name === selector) {
+                this._verbose({
+                    code: 'FOUND_MATCH',
+                    message: `found matching commit hash: ${ref.hash}`,
+                });
+                return ref.hash;
+            }
+        }
+
+        if (selector.length < 8) return null;
+
+        for (const ref of refs) {
+            if (ref.hash.startsWith(selector)) return ref.hash;
+        }
+    }
 }
 
 const supported = new Set(['github', 'gitlab', 'bitbucket']);
 
 function parse(src) {
-	const match = /^(?:https:\/\/([^/]+)\/|git@([^/]+):|([^/]+):)?([^/\s]+)\/([^/\s#]+)(?:#(.+))?/.exec(src);
-	if (!match) {
-		throw new DegitError(`could not parse ${src}`, {
-			code: 'BAD_SRC'
-		});
-	}
+    const match = /^(?:https:\/\/([^/]+)\/|git@([^/]+):|([^/]+):)?([^/\s]+)\/([^/\s#]+)(?:#(.+))?/.exec(
+        src
+    );
+    if (!match) {
+        throw new DegitError(`could not parse ${src}`, {
+            code: 'BAD_SRC',
+        });
+    }
 
-	const site = (match[1] || match[2] || match[3] || 'github').replace(/\.(com|org)$/, '');
-	if (!supported.has(site)) {
-		throw new DegitError(`degit supports GitHub, GitLab and BitBucket`, {
-			code: 'UNSUPPORTED_HOST'
-		});
-	}
+    const site = (match[1] || match[2] || match[3] || 'github').replace(
+        /\.(com|org)$/,
+        ''
+    );
+    if (!supported.has(site)) {
+        throw new DegitError(`degit supports GitHub, GitLab and BitBucket`, {
+            code: 'UNSUPPORTED_HOST',
+        });
+    }
 
-	const user = match[4];
-	const name = match[5].replace(/\.git$/, '');
-	const ref = match[6] || 'master';
+    const user = match[4];
+    const name = match[5].replace(/\.git$/, '');
+    const ref = match[6] || 'master';
 
-	const url = `https://${site}.${site === 'bitbucket' ? 'org' : 'com'}/${user}/${name}`;
+    const url = `https://${site}.${
+        site === 'bitbucket' ? 'org' : 'com'
+    }/${user}/${name}`;
 
-	return { site, user, name, ref, url };
+    return { site, user, name, ref, url };
 }
 
 async function untar(file, dest) {
-	return tar.extract({
-		file,
-		strip: 1,
-		C: dest
-	});
+    return tar.extract({
+        file,
+        strip: 1,
+        C: dest,
+    });
 }
 
 async function fetchRefs(repo) {
-	const { stdout } = await exec(`git ls-remote ${repo.url}`);
+    const { stdout } = await exec(`git ls-remote ${repo.url}`);
 
-	return stdout.split('\n').filter(Boolean).map(row => {
-		const [hash, ref] = row.split('\t');
+    return stdout
+        .split('\n')
+        .filter(Boolean)
+        .map(row => {
+            const [hash, ref] = row.split('\t');
 
-		if (ref === 'HEAD') {
-			return {
-				type: 'HEAD',
-				hash
-			};
-		}
+            if (ref === 'HEAD') {
+                return {
+                    type: 'HEAD',
+                    hash,
+                };
+            }
 
-		const match = /refs\/(\w+)\/(.+)/.exec(ref);
-		if (!match) throw new DegitError(`could not parse ${ref}`, { code: 'BAD_REF' });
+            const match = /refs\/(\w+)\/(.+)/.exec(ref);
+            if (!match)
+                throw new DegitError(`could not parse ${ref}`, {
+                    code: 'BAD_REF',
+                });
 
-		return {
-			type: (
-				match[1] === 'heads' ? 'branch' :
-				match[1] === 'refs' ? 'ref' :
-				match[1]
-			),
-			name: match[2],
-			hash
-		};
-	});
+            return {
+                type:
+                    match[1] === 'heads'
+                        ? 'branch'
+                        : match[1] === 'refs'
+                            ? 'ref'
+                            : match[1],
+                name: match[2],
+                hash,
+            };
+        });
 }
 
 function updateCache(dir, repo, hash, cached) {
-	if (cached[repo.ref] === hash) return;
+    if (cached[repo.ref] === hash) return;
 
-	const oldHash = cached[repo.ref];
-	if (oldHash) {
-		let used = false;
-		for (const key in cached) {
-			if (cached[key] === hash) {
-				used = true;
-				break;
-			}
-		}
+    const oldHash = cached[repo.ref];
+    if (oldHash) {
+        let used = false;
+        for (const key in cached) {
+            if (cached[key] === hash) {
+                used = true;
+                break;
+            }
+        }
 
-		if (!used) {
-			// we no longer need this tar file
-			try {
-				fs.unlinkSync(path.join(dir, `${oldHash}.tar.gz`));
-			} catch (err) {
-				// ignore
-			}
-		}
-	}
+        if (!used) {
+            // we no longer need this tar file
+            try {
+                fs.unlinkSync(path.join(dir, `${oldHash}.tar.gz`));
+            } catch (err) {
+                // ignore
+            }
+        }
+    }
 
-	cached[repo.ref] = hash;
-	fs.writeFileSync(path.join(dir, 'map.json'), JSON.stringify(cached, null, '  '));
+    cached[repo.ref] = hash;
+    fs.writeFileSync(
+        path.join(dir, 'map.json'),
+        JSON.stringify(cached, null, '  ')
+    );
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,176 +1,185 @@
-require("source-map-support").install();
+require('source-map-support').install();
 
-const fs = require("fs");
-const path = require("path");
-const glob = require("glob");
-const rimraf = require("rimraf").sync;
-const assert = require("assert");
-const child_process = require("child_process");
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+const rimraf = require('rimraf').sync;
+const assert = require('assert');
+const child_process = require('child_process');
 
-const degit = require("../index.js");
-const degitPath = path.resolve("bin.js");
+const degit = require('../index.js');
+const degitPath = path.resolve('bin.js');
 
 const timeout = 30000;
 
 function exec(cmd) {
-	return new Promise((fulfil, reject) => {
-		child_process.exec(cmd, (err, stdout, stderr) => {
-			if (err) return reject(err);
-			console.log(stdout);
-			console.error(stderr);
-			fulfil();
-		});
-	});
+    return new Promise((fulfil, reject) => {
+        child_process.exec(cmd, (err, stdout, stderr) => {
+            if (err) return reject(err);
+            console.log(stdout);
+            console.error(stderr);
+            fulfil();
+        });
+    });
 }
 
-describe("degit", function() {
-	this.timeout(timeout);
+describe('degit', function() {
+    this.timeout(timeout);
 
-	function compare(dir, files) {
-		const expected = glob.sync("**", { cwd: dir });
-		assert.deepEqual(Object.keys(files).sort(), expected.sort());
+    function compare(dir, files) {
+        const expected = glob.sync('**', { cwd: dir });
+        assert.deepEqual(Object.keys(files).sort(), expected.sort());
 
-		expected.forEach(file => {
-			if (!fs.lstatSync(`${dir}/${file}`).isDirectory()) {
-				assert.equal(files[file].trim(), read(`${dir}/${file}`).trim());
-			}
-		});
-	}
+        expected.forEach(file => {
+            if (!fs.lstatSync(`${dir}/${file}`).isDirectory()) {
+                assert.equal(files[file].trim(), read(`${dir}/${file}`).trim());
+            }
+        });
+    }
 
-	after(async () => await rimraf(".tmp"));
+    after(async () => await rimraf('.tmp'));
 
-	describe("github", () => {
-		beforeEach(() => rimraf(".tmp"));
+    describe('github', () => {
+        beforeEach(() => rimraf('.tmp'));
 
-		[
-			"mhkeller/degit-test-repo-compose",
-			"Rich-Harris/degit-test-repo",
-			"github:Rich-Harris/degit-test-repo",
-			"git@github.com:Rich-Harris/degit-test-repo",
-			"https://github.com/Rich-Harris/degit-test-repo.git"
-		].forEach(src => {
-			it(src, async () => {
-				await exec(`node ${degitPath} ${src} .tmp/test-repo -v`);
-				compare(`.tmp/test-repo`, {
-					"file.txt": "hello from github!"
-				});
-			});
-		});
-	});
+        [
+            'mhkeller/degit-test-repo-compose',
+            'Rich-Harris/degit-test-repo',
+            'github:Rich-Harris/degit-test-repo',
+            'git@github.com:Rich-Harris/degit-test-repo',
+            'https://github.com/Rich-Harris/degit-test-repo.git',
+        ].forEach(src => {
+            it(src, async () => {
+                await exec(`node ${degitPath} ${src} .tmp/test-repo -v`);
+                compare(`.tmp/test-repo`, {
+                    'file.txt': 'hello from github!',
+                });
+            });
+        });
+    });
 
-	describe("gitlab", () => {
-		beforeEach(() => rimraf(".tmp"));
+    describe('gitlab', () => {
+        beforeEach(() => rimraf('.tmp'));
 
-		[
-			"gitlab:Rich-Harris/degit-test-repo",
-			"git@gitlab.com:Rich-Harris/degit-test-repo",
-			"https://gitlab.com/Rich-Harris/degit-test-repo.git"
-		].forEach(src => {
-			it(src, async () => {
-				await exec(`node ${degitPath} ${src} .tmp/test-repo -v`);
-				compare(`.tmp/test-repo`, {
-					"file.txt": "hello from gitlab!"
-				});
-			});
-		});
-	});
+        [
+            'gitlab:Rich-Harris/degit-test-repo',
+            'git@gitlab.com:Rich-Harris/degit-test-repo',
+            'https://gitlab.com/Rich-Harris/degit-test-repo.git',
+        ].forEach(src => {
+            it(src, async () => {
+                await exec(`node ${degitPath} ${src} .tmp/test-repo -v`);
+                compare(`.tmp/test-repo`, {
+                    'file.txt': 'hello from gitlab!',
+                });
+            });
+        });
+    });
 
-	describe("bitbucket", () => {
-		beforeEach(() => rimraf(".tmp"));
+    describe('bitbucket', () => {
+        beforeEach(() => rimraf('.tmp'));
 
-		[
-			"bitbucket:Rich_Harris/degit-test-repo",
-			"git@bitbucket.org:Rich_Harris/degit-test-repo",
-			"https://bitbucket.org/Rich_Harris/degit-test-repo.git"
-		].forEach(src => {
-			it(src, async () => {
-				await exec(`node ${degitPath} ${src} .tmp/test-repo -v`);
-				compare(`.tmp/test-repo`, {
-					"file.txt": "hello from bitbucket"
-				});
-			});
-		});
-	});
+        [
+            'bitbucket:Rich_Harris/degit-test-repo',
+            'git@bitbucket.org:Rich_Harris/degit-test-repo',
+            'https://bitbucket.org/Rich_Harris/degit-test-repo.git',
+        ].forEach(src => {
+            it(src, async () => {
+                await exec(`node ${degitPath} ${src} .tmp/test-repo -v`);
+                compare(`.tmp/test-repo`, {
+                    'file.txt': 'hello from bitbucket',
+                });
+            });
+        });
+    });
 
-	describe("non-empty directories", () => {
-		it("fails without --force", async () => {
-			let succeeded;
+    describe('non-empty directories', () => {
+        it('fails without --force', async () => {
+            let succeeded;
 
-			try {
-				await exec(`echo "not empty" > .tmp/test-repo/file.txt`);
-				await exec(
-					`node ${degitPath} Rich-Harris/degit-test-repo .tmp/test-repo -v`
-				);
-				succeeded = true;
-			} catch (err) {
-				assert.ok(
-					/destination directory is not empty/.test(err.message)
-				);
-			}
+            try {
+                await exec(`echo "not empty" > .tmp/test-repo/file.txt`);
+                await exec(
+                    `node ${degitPath} Rich-Harris/degit-test-repo .tmp/test-repo -v`
+                );
+                succeeded = true;
+            } catch (err) {
+                assert.ok(
+                    /destination directory is not empty/.test(err.message)
+                );
+            }
 
-			assert.ok(!succeeded);
-		});
+            assert.ok(!succeeded);
+        });
 
-		it("succeeds with --force", async () => {
-			await exec(
-				`node ${degitPath} Rich-Harris/degit-test-repo .tmp/test-repo -fv`
-			);
-		});
-	});
+        it('succeeds with --force', async () => {
+            await exec(
+                `node ${degitPath} Rich-Harris/degit-test-repo .tmp/test-repo -fv`
+            );
+        });
+    });
 
-	describe("command line arguments", () => {
-		it("allows flags wherever", async () => {
-			await rimraf(".tmp");
+    describe('command line arguments', () => {
+        it('allows flags wherever', async () => {
+            await rimraf('.tmp');
 
-			await exec(
-				`node ${degitPath} -v Rich-Harris/degit-test-repo .tmp/test-repo`
-			);
-			compare(`.tmp/test-repo`, {
-				"file.txt": "hello from github!"
-			});
-		});
-	});
+            await exec(
+                `node ${degitPath} -v Rich-Harris/degit-test-repo .tmp/test-repo`
+            );
+            compare(`.tmp/test-repo`, {
+                'file.txt': 'hello from github!',
+            });
+        });
+    });
 
-	describe("api", () => {
-		it("is usable from node scripts", async () => {
-			await degit("Rich-Harris/degit-test-repo", { force: true }).clone(
-				".tmp/test-repo"
-			);
+    describe('api', () => {
+        it('is usable from node scripts', async () => {
+            await degit('Rich-Harris/degit-test-repo', { force: true }).clone(
+                '.tmp/test-repo'
+            );
 
-			compare(`.tmp/test-repo`, {
-				"file.txt": "hello from github!"
-			});
-		});
-	});
+            compare(`.tmp/test-repo`, {
+                'file.txt': 'hello from github!',
+            });
+        });
+    });
 
-	describe("actions", () => {
-		it("removes specified files", async () => {
-			await rimraf(".tmp");
+    describe('actions', () => {
+        it('removes specified file', async () => {
+            await rimraf('.tmp');
 
-			await exec(
-				`node ${degitPath} -v mhkeller/degit-test-repo-remove .tmp/test-repo`
-			);
-			compare(`.tmp/test-repo`, {
-				"other.txt": "hello from github!"
-			});
-		});
+            await exec(
+                `node ${degitPath} -v mhkeller/degit-test-repo-remove-only .tmp/test-repo`
+            );
+            compare(`.tmp/test-repo`, {});
+        });
 
-		it("removes and adds nested files", async () => {
-			await rimraf(".tmp");
+        it('clones repo and removes specified file', async () => {
+            await rimraf('.tmp');
 
-			await exec(
-				`node ${degitPath} -v mhkeller/degit-test-repo-nested-actions .tmp/test-repo`
-			);
-			compare(`.tmp/test-repo`, {
-				dir: "",
-				folder: "",
-				"folder/file.txt": "hello from clobber file!",
-				"folder/other.txt": "hello from other file!"
-			});
-		});
-	});
+            await exec(
+                `node ${degitPath} -v mhkeller/degit-test-repo-remove .tmp/test-repo`
+            );
+            compare(`.tmp/test-repo`, {
+                'other.txt': 'hello from github!',
+            });
+        });
+
+        it('removes and adds nested files', async () => {
+            await rimraf('.tmp');
+
+            await exec(
+                `node ${degitPath} -v mhkeller/degit-test-repo-nested-actions .tmp/test-repo`
+            );
+            compare(`.tmp/test-repo`, {
+                dir: '',
+                folder: '',
+                'folder/file.txt': 'hello from clobber file!',
+                'folder/other.txt': 'hello from other file!',
+            });
+        });
+    });
 });
 
 function read(file) {
-	return fs.readFileSync(file, "utf-8");
+    return fs.readFileSync(file, 'utf-8');
 }


### PR DESCRIPTION
Per https://github.com/Rich-Harris/degit/issues/38, this will now only stash files on your first clone. I'll walk through how this works with an example. The README should be more clear as well so if this seems like sound logic, I'll update that language in this PR.

You are using degit to initialize a repo that has three files:

```
degit.json
HELLO.md
```

Where degit.json looks like this:

```js
[
  { action: 'clone', src: 'foo/bar' },
  { action: 'remove', files: [ 'baz.md' ] },
  { action: 'clone', src: 'bar/foo' },
]
```

1. Download the repo
2. Read in the degit.json file
3. When it gets to the first `clone` action, stash the current working directories files – in this case HELLO.md and degit.json – and then do the clone. The current working directory now only contains the repo specified in this action, `foo/bar`
4. If you have a `remove` action here, that proceeds normally on the currently working directory.
5. If you have a second clone, that will be degited with `--force` and clobber any existing files in the working directory if their paths are the same.
6. Since we're all done with our actions, unstash the original working directory, excluding the degit.json file, since we don't need it any more. In this example, that means bringing back HELLO.md, which will clobber any existing HELLO.md in the root folder. 

The reason for stashing and unstashing is it's how you can add files on top of any repos you are cloning. 

Does that make sense?