### PR TITLE
Implement fetching subdir from repo (fixes #48)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,8 @@ class Degit extends EventEmitter {
 			? this._getHashFromCache(repo, cached)
 			: await this._getHash(repo, cached);
 
+		const subdir = repo.subdir ? `${repo.name}-${hash}${repo.subdir}` : null;
+
 		if (!hash) {
 			// TODO 'did you mean...?'
 			throw new DegitError(`could not find commit hash for ${repo.ref}`, {
@@ -137,11 +139,13 @@ class Degit extends EventEmitter {
 
 		this._verbose({
 			code: 'EXTRACTING',
-			message: `extracting ${file} to ${dest}`,
+			message: `extracting ${
+				subdir ? repo.subdir + ' from ' : ''
+			}${file} to ${dest}`,
 		});
 
 		mkdirp(dest);
-		await untar(file, dest);
+		await untar(file, dest, subdir);
 
 		this._info({
 			code: 'SUCCESS',
@@ -288,7 +292,7 @@ class Degit extends EventEmitter {
 const supported = new Set(['github', 'gitlab', 'bitbucket', 'git.sr.ht']);
 
 function parse(src) {
-	const match = /^(?:https:\/\/([^/]+)\/|git@([^/]+)[:/]|([^/]+)[:/])?([^/\s]+)\/([^/\s#]+)(?:#(.+))?/.exec(
+	const match = /^(?:(?:https:\/\/)?([^:/]+\.[^:/]+)\/|git@([^:/]+)[:/]|([^/]+):)?([^/\s]+)\/([^/\s#]+)(?:((?:\/[^/\s#]+)+))?(?:\/)?(?:#(.+))?/.exec(
 		src
 	);
 	if (!match) {
@@ -312,21 +316,25 @@ function parse(src) {
 
 	const user = match[4];
 	const name = match[5].replace(/\.git$/, '');
-	const ref = match[6] || 'master';
+	const subdir = match[6];
+	const ref = match[7] || 'master';
 
 	const url = `https://${site}.${
 		site === 'bitbucket' ? 'org' : site === 'git.sr.ht' ? '' : 'com'
 	}/${user}/${name}`;
 
-	return { site, user, name, ref, url };
+	return { site, user, name, ref, url, subdir };
 }
 
-async function untar(file, dest) {
-	return tar.extract({
-		file,
-		strip: 1,
-		C: dest,
-	});
+async function untar(file, dest, subdir = null) {
+	return tar.extract(
+		{
+			file,
+			strip: subdir ? subdir.split('/').length : 1,
+			C: dest,
+		},
+		subdir ? [subdir] : []
+	);
 }
 
 async function fetchRefs(repo) {


### PR DESCRIPTION
This PR solves issue #48, so an user can request a subdirectory from the git repo and then those files appear inside destination.

When the regex finds a subdirectory, only the specified path is extracted from the .tar.gz, other files are still there but ignored.

The regex was tested with these requests by hand

```
user/repo/foo/bar/
github.com/user/repo/foo/bar
github:user/repo/foo/bar
git@github.com:user/repo/foo/bar
https://github.com/user/repo/foo/bar

gitlab:user/repo/foo/bar
git@gitlab.com:user/repo/foo/bar
git@gitlab.com/user/repo/foo/bar
https://gitlab.com/user/repo/foo/bar

bitbucket:user/repo/foo/bar
git@bitbucket.org:user/repo/foo/bar
https://bitbucket.org/user/repo/foo/bar

git.sr.ht/user/repo/foo/bar
git@git.sr.ht:user/repo/foo/bar
https://git.sr.ht/user/repo/foo/bar

user/repo/foo/bar/#dev
user/repo/foo/bar/#v1.2.3
user/repo/foo/bar/#1234abcd
```