### PR TITLE
Speed up git mode by doing a shallow clone

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -314,7 +314,7 @@ class Degit extends EventEmitter {
 	}
 
 	async _cloneWithGit(dir, dest) {
-		await exec(`git clone ${this.repo.ssh} ${dest}`);
+		await exec(`git clone --depth 1 ${this.repo.ssh} ${dest}`);
 		await exec(`rm -rf ${path.resolve(dest, '.git')}`);
 	}
 }


### PR DESCRIPTION
Speed up git mode by doing a shallow clone: `--depth 1`

I guess this would be a breaking change, since git has not supported the `--depth` flag forever. (From what I can tell, it was introduced in [git 1.5.0](https://github.com/git/git/releases/tag/v1.5.0) which was released 13 years ago.)