### PR TITLE
Fix some Windows tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -27,6 +27,14 @@ describe('degit', function() {
 	this.timeout(timeout);
 
 	function compare(dir, files) {
+		if (path.sep !== '/') {
+			files = Object.keys(files).reduce((newFiles, file) => {
+				const newFilePath = file.replace(/\//g, path.sep);
+				newFiles[ newFilePath ] = files[file];
+				return newFiles;
+			}, {});
+		}
+
 		const expected = glob('**', { cwd: dir });
 		assert.deepEqual(Object.keys(files).sort(), expected.sort());
 


### PR DESCRIPTION
A bunch of the tests were failing on Windows because of the path separator.

This PR fixes that issue.

At least one of the tests still fail for me, but I don't have access to that private git repo `Rich-Harris/degit-test-repo-private`...