### PR TITLE
Use rimrafSync instead of rm -rf in --mode=git

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -315,7 +315,7 @@ class Degit extends EventEmitter {
 
 	async _cloneWithGit(dir, dest) {
 		await exec(`git clone ${this.repo.ssh} ${dest}`);
-		await exec(`rm -rf ${path.resolve(dest, '.git')}`);
+		rimrafSync(path.resolve(dest, '.git'));
 	}
 }
 


### PR DESCRIPTION
I get the following error when using `--mode=git` with a private repository in Windows (PowerShell):
```
! Command failed: rm -rf E:\dev\test\.git
'rm' is not recognized as an internal or external command,
operable program or batch file.
```
Since `rm` is not avaliable in PowerShell and I saw that you were already using rimraf you could use that instead and not be tied to a unix environment.