### PR TITLE
fallback to main branch if master doesn't exist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -204,7 +204,12 @@ class Degit extends EventEmitter {
 			let ref = this._selectRef(refs, repo.ref);
 
 			// could not find master - if master was not specifically requested, try to find main
-			if (!ref && repo.ref === 'master' && !repo.requestedRef) {
+			if (
+				!ref &&
+				repo.ref === 'master' &&
+				!repo.requestedRef &&
+				repo.site === 'github'
+			) {
 				ref = this._selectRef(refs, 'main');
 
 				if (ref) {


### PR DESCRIPTION
GitHub uses `main` as the default branch for all new repositories as of [Oct 1, 2020](https://github.com/github/renaming#later-this-year). As discussed in #207, this leads to degit failing unless you specify `#main` to the URL. 

This PR adds support to fallback to `main` if the following is true:

- No branch or hash is specified (`degit Rich-Harris/degit`)
- `master` branch cannot be found
- is a github.com repo
