### PR TITLE
🐛 Use any default branch instead of `master`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -201,6 +201,9 @@ class Degit extends EventEmitter {
 	async _getHash(repo, cached) {
 		try {
 			const refs = await fetchRefs(repo);
+			if (repo.ref === 'HEAD') {
+				return refs.find(ref => ref.type === 'HEAD').hash;
+			}
 			return this._selectRef(refs, repo.ref);
 		} catch (err) {
 			this._warn(err);
@@ -347,7 +350,7 @@ function parse(src) {
 	const user = match[4];
 	const name = match[5].replace(/\.git$/, '');
 	const subdir = match[6];
-	const ref = match[7] || 'master';
+	const ref = match[7] || 'HEAD';
 
 	const domain = `${site}.${
 		site === 'bitbucket' ? 'org' : site === 'git.sr.ht' ? '' : 'com'


### PR DESCRIPTION
Replaces and closes #235 
Replaces and closes #204
Fixes #207 
Fixes #37
Fixes #254 
Closes #242 

The solution is simple if you detach yourself from `master === default` and instead use the HEAD as the right terminology in a remote server.

This could alternatively internally referred to as `<default>` instead of `HEAD`, but I like minimal-impact PRs.

---

Also available in the https://github.com/tiged/tiged community fork