### PR TITLE
Fix gitlab tarball url

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -264,7 +264,7 @@ class Degit extends EventEmitter {
 		const file = `${dir}/${hash}.tar.gz`;
 		const url =
 			repo.site === 'gitlab'
-				? `${repo.url}/repository/archive.tar.gz?ref=${hash}`
+				? `${repo.url}/-/archive/${hash}/${repo.name}-${hash}.tar.gz`
 				: repo.site === 'bitbucket'
 				? `${repo.url}/get/${hash}.tar.gz`
 				: `${repo.url}/archive/${hash}.tar.gz`;


### PR DESCRIPTION
Gitlab related tests failed.

- prev: https://gitlab.com/Rich-Harris/degit-test-repo/repository/archive.tar.gz?ref=master
- now: https://gitlab.com/Rich-Harris/degit-test-repo/-/archive/master/degit-test-repo-master.tar.gz
