### PR TITLE
Deprecate node.js v8 on CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - '8'
   - '10'
+  - '12'
   - lts/*
   - node
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ init:
 environment:
   matrix:
     # node.js
-    - nodejs_version: 8
+    - nodejs_version: 10
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
CI using node.js vesion 8  failed because `eslint@7.23.0: wanted: {"node":"^10.12.0 || >=12.0.0"}` .
It may be better to deprecate this version of tests.