### PR TITLE
Exporting parse function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ import {
 
 const validModes = new Set(['tar', 'git']);
 
+export { parseSpec };
+
 export default function degit(src, opts) {
 	return new Degit(src, opts);
 }


### PR DESCRIPTION
What do you think about:
- Putting the parse function in the `utils.js`
- renaming to `parseSpec` for a little clarity
- exporting from package for external use?

unrelated... sorry, I just noticed I apparently changed your `fulfil` to `resolve` without noticing... 🤔 