### PR TITLE
Use spawn for ls-remote to avoid large output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import { rimrafSync } from 'sander';
 import {
 	DegitError,
 	exec,
+	spawn,
 	fetch,
 	mkdirp,
 	tryRequire,
@@ -252,7 +253,6 @@ class Degit extends EventEmitter {
 			: await this._getHash(repo, cached);
 
 		const subdir = repo.subdir ? `${repo.name}-${hash}${repo.subdir}` : null;
-
 		if (!hash) {
 			// TODO 'did you mean...?'
 			throw new DegitError(`could not find commit hash for ${repo.ref}`, {
@@ -376,7 +376,7 @@ async function untar(file, dest, subdir = null) {
 
 async function fetchRefs(repo) {
 	try {
-		const { stdout } = await exec(`git ls-remote ${repo.url}`);
+		const { stdout } = await spawn(`git ls-remote ${repo.url}`);
 
 		return stdout
 			.split('\n')

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,6 +43,30 @@ export function exec(command) {
 	});
 }
 
+export function spawn(command) {
+	const decoder = new TextDecoder();
+	return new Promise((fulfil, reject) => {
+		const args = command.split(' ');
+		const cmd = args.shift();
+		const ps = child_process.spawn(cmd, args);
+		const outs = [];
+		const errs = [];
+		ps.stdout.on('data', (data) => {
+			outs.push(decoder.decode(data));
+		});
+		ps.stderr.on('data', (data) => {
+			errs.push(decoder.decode(data));
+		});
+		ps.on('close', (code) => {
+			if (code != 0) {
+				reject(code);
+			} else {
+				fulfil({ stdout: outs.join(''), stderr: errs.join('') });
+			}
+		});
+	});
+}
+
 export function mkdirp(dir) {
 	const parent = path.dirname(dir);
 	if (parent === dir) return;


### PR DESCRIPTION
`exec`'s output is buffered and has limit of 1m by default. It's better to use spawn instead for big repo with lots of refs. One exmple repo is this one: https://github.com/vercel/next.js and is causing exec to fail.