### PR TITLE
fix: Exit direcly after the cloning is complete

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -58,15 +58,17 @@ export function mkdirp(dir) {
 
 export function fetch(url, dest, proxy) {
 	return new Promise((fulfil, reject) => {
-		let options = url;
-
+		const parsedUrl = URL.parse(url);
+		const options = {
+			hostname: parsedUrl.hostname,
+			port: parsedUrl.port,
+			path: parsedUrl.path,
+			headers: {
+				Connection: 'close'
+			}
+		};
 		if (proxy) {
-			const parsedUrl = URL.parse(url);
-			options = {
-				hostname: parsedUrl.host,
-				path: parsedUrl.path,
-				agent: new Agent(proxy)
-			};
+			options.agent = new Agent(proxy);
 		}
 
 		https


### PR DESCRIPTION
When no cache exists one of the https.get calls is keeping the node process alive much longer than needed.
This is causing (minutes) of unneeded delay before the degit command completes successfully.

Adding the `Connection: close` header causes the client to clean up after every request.