### PR TITLE
Implements #364

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ emitter.clone('path/to/dest').then(() => {
 
 ## Actions
 
-You can manipulate repositories after they have been cloned with _actions_, specified in a `degit.json` file that lives at the top level of the working directory. Currently, there are two actions — `clone` and `remove`. Additional actions may be added in future.
+You can manipulate repositories after they have been cloned with _actions_, specified in a `degit.json` file that lives at the top level of the working directory. Currently, there are three actions — `clone`, `remove`, and `search_replace`. Additional actions may be added in future.
 
 ### clone
 
@@ -163,6 +163,26 @@ This will clone `user/another-repo`, preserving the contents of the existing wor
 ```
 
 Remove a file at the specified path.
+
+### search_replace
+
+```json
+// degit.json
+[
+	{
+		"action": "search_replace",
+		"files": [
+			"one.txt",
+			"two.json",
+			"three.mjs"
+		],
+		"pattern": "\\{\\{name\\}\\}",
+		"replacement": "PROJECT_NAME"
+	}
+]
+```
+
+This will perform a search-and-replace in the given plaintext files. For example, this can be used to populate a project with an initial name, or various "author" references with email addresses, etc. The replacement regular expression is defined by the `pattern` field; matches in those files will be replaced by the value of the environmental variable identified by the `replacement` value in the user runtime. For example, the configuration listed above will replace all occurances of `{{name}}` in the given files with the value of the environmental variable `$PROJECT_NAME`.
 
 ## See also
 

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ class Degit extends EventEmitter {
 	}
 
 	search_replace(dir, dest, action) {
-		const re = new RegExp(action.pattern);
+		const re = new RegExp(action.pattern, 'g');
 		const value = process.env[action.replacement];
 		action.files.forEach(file => {
 			const file_path = `${dest}${path.sep}${file}`;

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import process from 'process';
 import fs from 'fs';
 import path from 'path';
 import tar from 'tar';
@@ -70,7 +71,8 @@ class Degit extends EventEmitter {
 					process.exit(1);
 				});
 			},
-			remove: this.remove.bind(this)
+			remove: this.remove.bind(this),
+			search_replace: this.search_replace.bind(this)
 		};
 	}
 
@@ -156,6 +158,17 @@ class Degit extends EventEmitter {
 				)}`
 			});
 		}
+	}
+
+	search_replace(dir, dest, action) {
+		const re = new RegExp(action.pattern);
+		const value = process.env[action.replacement];
+		action.files.forEach(file => {
+			const file_path = `${dest}${path.sep}${file}`;
+			let contents = fs.readFileSync(file_path, "utf8");
+			contents = contents.replace(re, value);
+			fs.writeFileSync(file_path, contents);
+		});
 	}
 
 	_checkDirIsEmpty(dir) {


### PR DESCRIPTION
#364 suggestion implemented with several small adjustments:

* arguments are not used as the source of replacement value definitions; they are instead evaluated against environmental variables (from the user runtime) identified by the `replacement` string in the action definition.

An example working `degit.json` can be seen here:

https://github.com/Tythos/degit-template-zigexe/blob/master/degit.json

In this example, all instances of the pattern `r/{{project_name}}/` will be replaced by the value of the environmental variable `$PROJECT_NAME`. (This makes it easy to pass/forward values from other calls, or inline within the same shell command, without adjusting any of the argument parsing behavior. Documentation to README has also been added to reflect this usage.
