### PR TITLE
feat: show more logs when cloned proj error

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -135,6 +135,8 @@ function run(src, dest, args) {
 
 	d.clone(dest).catch(err => {
 		console.error(chalk.red(`! ${err.message.replace('options.', '--')}`));
+		// show more logs when cloned proj error
+		console.warn(chalk.yellow(`！original: ${JSON.stringify(err.original)}`))
 		process.exit(1);
 	});
 }


### PR DESCRIPTION
When I clone a private repository with degit, the clone fails without any git configured and the reason for the failure is not shown, so I think more failure information is needed to help users find the problem

![image](https://github.com/Rich-Harris/degit/assets/155932350/7c5bc639-b706-407b-9a76-0d8495f007c7)
