### PR TITLE
fix: remove .git file in windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -318,7 +318,7 @@ class Degit extends EventEmitter {
 
 	async _cloneWithGit(dir, dest) {
 		await exec(`git clone ${this.repo.ssh} ${dest}`);
-		await exec(`rm -rf ${path.resolve(dest, '.git')}`);
+		rimrafSync(path.resolve(dest, '.git'));
 	}
 }
 


### PR DESCRIPTION
`_cloneWithGit` will delete `.git` file when `git clone` succeed, but `rm -rf` is not supported in widnows. 