### PR TITLE
chore(editorconfig) align indentation and whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,15 +3,8 @@ root = true
 
 [*]
 charset = utf-8
-indent_size = 2
-indent_style = tab
 end_of_line = lf
-trim_trailing_whitespace = true
+indent_size = 4
+indent_style = tab
 insert_final_newline = true
-
-[*.md]
-indent_style = tab
-trim_trailing_whitespace = false
-
-[{*.json,*.yml}]
-indent_style = tab
+trim_trailing_whitespace = true


### PR DESCRIPTION
## Summary
### What
- Simplifies `.editorconfig`: global `indent_size` 4 with tab style, consistent `insert_final_newline` and `trim_trailing_whitespace`, removes per-pattern overrides for `*.md` and `{*.json,*.yml}`.

### Why
- Aligns editor defaults across the repo and reduces special-case rules for markdown and JSON/YAML.

## Changes
- `.editorconfig`: drop markdown-specific `trim_trailing_whitespace` exception and JSON/YAML block; set `indent_size = 4` at root.

## Testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] CLI smoke run
- Commands run:
- Repro steps:
  1. Open repo in an EditorConfig-aware editor.
  2. Confirm indentation and trim settings match `.editorconfig` for typical files.
  3. 
- Expected output / evidence:
- Editor respects root `indent_size` / `indent_style` / newline and trim settings.

## Risk and rollout
- Risk level: Low
- Breaking changes: None to runtime; editor behavior may differ for `.md` / `.json` / `.yml` (trailing whitespace trimming, indentation width).
- Rollback plan: Revert commit or restore previous `.editorconfig` sections.
- Flags/commands affected: None

## Checklist
- [ ] CLI behavior is covered by the scenario changed
- [ ] Exit codes are considered and validated where relevant
- [ ] Error handling was reviewed (including edge cases)
- [ ] Help text, man page, completion, docs updated if needed
- [x] No unrelated changes
- [ ] Relevant tests added or updated
- [ ] CI checks pass