### PR TITLE
chore(workflows) add anti-slop PR check

### DIFF
--- a/.github/workflows/anti-slop.yml
+++ b/.github/workflows/anti-slop.yml
@@ -1,0 +1,19 @@
+name: PR Quality
+
+permissions:
+    contents: read
+    issues: read
+    pull-requests: write
+
+on:
+    pull_request_target:
+        types: [opened, reopened, synchronize]
+
+jobs:
+    anti-slop:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: peakoss/anti-slop@57858eead489d08b255fab2af45a506c2ca6eab2
+              with:
+                  max-failures: 4


### PR DESCRIPTION
## Summary

Add a new GitHub Actions workflow that runs the `peakoss/anti-slop` check on pull requests, pinned to a specific SHA and triggered on `opened`, `reopened`, and `synchronize`.

## Why

Catch low-quality PRs earlier with a conservative, reviewable setup while avoiding a moving tag.

## Changes

- Added `.github/workflows/anti-slop.yml`
- Pinned the action to `57858eead489d08b255fab2af45a506c2ca6eab2`
- Configured `pull_request_target` with `opened`, `reopened`, and `synchronize`
- Kept permissions limited to `contents: read`, `issues: read`, and `pull-requests: write`

## Testing

How you verified this (commands, scenarios, or N/A):

- [ ] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes**: none

**Risks / rollout**: This adds a PR workflow that can close or label pull requests based on the action’s checks.

**Focus areas for reviewers**: Workflow trigger, pinned SHA, and permissions.

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
