### PR TITLE
test(bin): verify packaged root bin

### DIFF
--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -1,5 +1,8 @@
 import sourceMapSupport from 'source-map-support';
 import assert from 'node:assert';
+import child_process from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { sync as rimraf } from 'rimraf';
 
 sourceMapSupport.install();
@@ -26,6 +29,8 @@ async function waitForCondition(fn, timeoutMs = 3000) {
 
 describe('degit bin', () => {
 	const binTmp = '.tmp/bin-suite';
+	const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+	const rootBin = path.join(repoRoot, 'degit');
 
 	beforeEach(async () => {
 		await rimraf(binTmp);
@@ -36,6 +41,18 @@ describe('degit bin', () => {
 		});
 	});
 	afterEach(async () => await rimraf(binTmp));
+
+	it('runs the built root bin after build', () => {
+		const output = child_process.execFileSync('node', [rootBin, '--help'], {
+			env: {
+				...process.env,
+				VITEST: '',
+			},
+			encoding: 'utf8',
+		});
+		assert.ok(output.includes('Usage'));
+		assert.ok(output.includes('degit'));
+	});
 
 	it('writes help to stdout when argv includes --help', async () => {
 		const chunks = [];


### PR DESCRIPTION
## Summary

**What**

Add a post-build integration test that exercises the root `degit` wrapper with `--help`.

**Why**

This catches packaging or entrypoint regressions that direct imports of `src/bin.js` would miss.

## Changes

- Added a test in `test/bin.test.js` that runs `node degit --help` from the built package root.
- Cleared `VITEST` in the spawned process so the CLI auto-executes during the integration check.
- Kept the existing mocked unit coverage intact.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [x] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes** (or none)

none

**Risks / rollout** (or none)

Low risk. The new check is read-only and only exercises the packaged wrapper help path.

**Focus areas for reviewers** (optional)

The new post-build invocation in `test/bin.test.js`.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
