### PR TITLE
chore(release) sync 2.8.5 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # degit changelog
 
+## 2.8.5
+
+- Final v2 security patch; keep Node 8 compatibility on the legacy line.
+- Node 20 starts with v3.
+
 ## 2.8.4
 
 - Whoops

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "2.8.4",
+	"version": "2.8.5",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",


### PR DESCRIPTION
## Summary

**What**

Bump the `master` branch release metadata to `2.8.5` and add the matching changelog entry.

**Why**

Keep the mainline branch in sync with the published patch release so it no longer advertises `2.8.4`.

## Changes

- Update `package.json` to `2.8.5`.
- Add the `2.8.5` changelog entry at the top of `CHANGELOG.md`.

## Testing

How you verified this (commands, scenarios, or N/A):

- `git diff --check`

- [ ] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes**: none

**Risks / rollout**: none

**Focus areas for reviewers**: release metadata only

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes