### PR TITLE
chore(ci): add JS-only CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: 'CodeQL Advanced'
+
+on:
+    pull_request:
+        branches: ['master']
+    schedule:
+        - cron: '30 1 * * 6'
+
+jobs:
+    analyze:
+        name: Analyze (${{ matrix.language }})
+        runs-on: ubuntu-latest
+        permissions:
+            security-events: write
+
+            packages: read
+
+            actions: read
+            contents: read
+
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - language: javascript-typescript
+                      build-mode: none
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v4
+              with:
+                  languages: ${{ matrix.language }}
+                  build-mode: ${{ matrix.build-mode }}
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v4
+              with:
+                  category: '/language:${{matrix.language}}'


### PR DESCRIPTION
## Summary

**What**

Add a JavaScript-only CodeQL workflow for this repository.

**Why**

Keep CodeQL scanning focused on the JavaScript/TypeScript codebase.

## Changes

- Add `.github/workflows/codeql.yml` with a `javascript-typescript` matrix entry and `build-mode: none`.
- Trigger the workflow on pull requests to `master` and on a weekly schedule.

## Testing

How you verified this (commands, scenarios, or N/A):

- N/A: metadata-only PR update.

- [ ] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes** none

**Risks / rollout** low; workflow-only change

**Focus areas for reviewers** CodeQL job configuration and trigger scope

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
