### PR TITLE
refactor: centralize git provider metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,43 @@ import {
 
 const validModes = new Set(['tar', 'git']);
 
+const supported = new Set(['github', 'gitlab', 'bitbucket', 'git.sr.ht']);
+
+function getProvider(site) {
+	switch (site) {
+		case 'github':
+			return {
+				domain: 'github.com',
+				archiveUrl(repo, hash) {
+					return `${repo.url}/archive/${hash}.tar.gz`;
+				},
+			};
+		case 'gitlab':
+			return {
+				domain: 'gitlab.com',
+				archiveUrl(repo, hash) {
+					return `${repo.url}/repository/archive.tar.gz?ref=${hash}`;
+				},
+			};
+		case 'bitbucket':
+			return {
+				domain: 'bitbucket.org',
+				archiveUrl(repo, hash) {
+					return `${repo.url}/get/${hash}.tar.gz`;
+				},
+			};
+		case 'git.sr.ht':
+			return {
+				domain: 'git.sr.ht',
+				archiveUrl(repo, hash) {
+					return `${repo.url}/archive/${hash}.tar.gz`;
+				},
+			};
+		default:
+			return undefined;
+	}
+}
+
 export default function degit(src, opts) {
 	return new Degit(src, opts);
 }
@@ -260,12 +297,7 @@ class Degit extends EventEmitter {
 		}
 
 		const file = `${dir}/${hash}.tar.gz`;
-		const url =
-			repo.site === 'gitlab'
-				? `${repo.url}/repository/archive.tar.gz?ref=${hash}`
-				: repo.site === 'bitbucket'
-					? `${repo.url}/get/${hash}.tar.gz`
-					: `${repo.url}/archive/${hash}.tar.gz`;
+		const url = getProvider(repo.site).archiveUrl(repo, hash);
 
 		try {
 			if (!this.cache) {
@@ -323,8 +355,6 @@ class Degit extends EventEmitter {
 	}
 }
 
-const supported = new Set(['github', 'gitlab', 'bitbucket', 'git.sr.ht']);
-
 function parse(src) {
 	const [source, refValue = 'HEAD'] = src.split('#', 2);
 	let site = 'github';
@@ -362,6 +392,8 @@ function parse(src) {
 		});
 	}
 
+	const provider = getProvider(site);
+
 	const [user, rawName, ...subdirParts] = remainder.split('/').filter(Boolean);
 	if (!user || !rawName) {
 		throw new DegitError(`could not parse ${src}`, {
@@ -373,12 +405,11 @@ function parse(src) {
 	const subdir = subdirParts.length > 0 ? `/${subdirParts.join('/')}` : undefined;
 	const ref = refValue;
 
-	const domain =
-		site === 'git.sr.ht' ? 'git.sr.ht' : site === 'bitbucket' ? `${site}.org` : `${site}.com`;
+	const domain = provider.domain;
 	const url = `https://${domain}/${user}/${name}`;
 	const ssh = `git@${domain}:${user}/${name}`;
 
-	const mode = supported.has(site) ? 'tar' : 'git';
+	const mode = 'tar';
 
 	return { mode, name, ref, site, ssh, subdir, url, user };
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -17,62 +17,75 @@ sourceMapSupport.install();
 
 const refsHash = '0123456789abcdef0123456789abcdef0123456789';
 
+function createProviderCase({ build, domain, publicSrc, redirectUrl, site, user }) {
+	const name = 'degit-test-repo';
+	const privateName = `${name}-private`;
+	const url = `https://${domain}/${user}/${name}`;
+	return {
+		...build({ domain, name, privateName, url, user }),
+		name,
+		privateName,
+		publicSrc,
+		redirectUrl,
+		site,
+		url,
+		user,
+	};
+}
+
 const providerCases = [
-	{
-		archiveUrl: (hash) =>
-			`https://github.com/Rich-Harris/degit-test-repo/archive/${hash}.tar.gz`,
-		gitSrc: 'https://github.com/Rich-Harris/degit-test-repo-private.git',
-		lsRemote: 'git ls-remote https://github.com/Rich-Harris/degit-test-repo',
-		name: 'degit-test-repo',
-		privateName: 'degit-test-repo-private',
+	createProviderCase({
+		domain: 'github.com',
 		publicSrc: 'Rich-Harris/degit-test-repo',
 		redirectUrl: 'https://github.com/forbidden',
 		site: 'github',
-		ssh: 'git@github.com:Rich-Harris/degit-test-repo',
-		url: 'https://github.com/Rich-Harris/degit-test-repo',
 		user: 'Rich-Harris',
-	},
-	{
-		archiveUrl: (hash) =>
-			`https://gitlab.com/Rich-Harris/degit-test-repo/repository/archive.tar.gz?ref=${hash}`,
-		gitSrc: 'gitlab:Rich-Harris/degit-test-repo-private',
-		lsRemote: 'git ls-remote https://gitlab.com/Rich-Harris/degit-test-repo',
-		name: 'degit-test-repo',
-		privateName: 'degit-test-repo-private',
+		build: ({ domain, name, privateName, url, user }) => ({
+			archiveUrl: (hash) => `${url}/archive/${hash}.tar.gz`,
+			gitSrc: `https://${domain}/${user}/${privateName}.git`,
+			lsRemote: `git ls-remote ${url}`,
+			ssh: `git@${domain}:${user}/${name}`,
+		}),
+	}),
+	createProviderCase({
+		domain: 'gitlab.com',
 		publicSrc: 'gitlab:Rich-Harris/degit-test-repo',
 		redirectUrl: 'https://gitlab.com/forbidden',
 		site: 'gitlab',
-		ssh: 'git@gitlab.com:Rich-Harris/degit-test-repo',
-		url: 'https://gitlab.com/Rich-Harris/degit-test-repo',
 		user: 'Rich-Harris',
-	},
-	{
-		archiveUrl: (hash) =>
-			`https://bitbucket.org/Rich_Harris/degit-test-repo/get/${hash}.tar.gz`,
-		gitSrc: 'bitbucket:Rich_Harris/degit-test-repo-private',
-		lsRemote: 'git ls-remote https://bitbucket.org/Rich_Harris/degit-test-repo',
-		name: 'degit-test-repo',
-		privateName: 'degit-test-repo-private',
+		build: ({ domain, name, privateName, url, user }) => ({
+			archiveUrl: (hash) => `${url}/repository/archive.tar.gz?ref=${hash}`,
+			gitSrc: `gitlab:${user}/${privateName}`,
+			lsRemote: `git ls-remote ${url}`,
+			ssh: `git@${domain}:${user}/${name}`,
+		}),
+	}),
+	createProviderCase({
+		domain: 'bitbucket.org',
 		publicSrc: 'bitbucket:Rich_Harris/degit-test-repo',
 		redirectUrl: 'https://bitbucket.org/forbidden',
 		site: 'bitbucket',
-		ssh: 'git@bitbucket.org:Rich_Harris/degit-test-repo',
-		url: 'https://bitbucket.org/Rich_Harris/degit-test-repo',
 		user: 'Rich_Harris',
-	},
-	{
-		archiveUrl: (hash) => `https://git.sr.ht/~satotake/degit-test-repo/archive/${hash}.tar.gz`,
-		gitSrc: 'git.sr.ht/~satotake/degit-test-repo-private',
-		lsRemote: 'git ls-remote https://git.sr.ht/~satotake/degit-test-repo',
-		name: 'degit-test-repo',
-		privateName: 'degit-test-repo-private',
+		build: ({ domain, name, privateName, url, user }) => ({
+			archiveUrl: (hash) => `${url}/get/${hash}.tar.gz`,
+			gitSrc: `bitbucket:${user}/${privateName}`,
+			lsRemote: `git ls-remote ${url}`,
+			ssh: `git@${domain}:${user}/${name}`,
+		}),
+	}),
+	createProviderCase({
+		domain: 'git.sr.ht',
 		publicSrc: 'git.sr.ht/~satotake/degit-test-repo',
 		redirectUrl: 'https://git.sr.ht/forbidden',
 		site: 'git.sr.ht',
-		ssh: 'git@git.sr.ht:~satotake/degit-test-repo',
-		url: 'https://git.sr.ht/~satotake/degit-test-repo',
 		user: '~satotake',
-	},
+		build: ({ domain, name, privateName, url, user }) => ({
+			archiveUrl: (hash) => `${url}/archive/${hash}.tar.gz`,
+			gitSrc: `git.sr.ht/${user}/${privateName}`,
+			lsRemote: `git ls-remote ${url}`,
+			ssh: `git@${domain}:${user}/${name}`,
+		}),
+	}),
 ];
 
 async function createArchiveFixture(rootName) {


### PR DESCRIPTION
## Summary

**What**

Centralize provider-specific metadata into a single table and use it for archive URL generation, domain selection, and supported-provider handling.

**Why**

Keep provider behavior consistent in one place and make it easier to extend or audit supported hosts.

## Changes

- Added a provider metadata map in `src/index.ts` for GitHub, GitLab, Bitbucket, and git.sr.ht.
- Switched archive URL resolution and parsed repository URL/domain selection to use the shared provider metadata.
- Updated the provider coverage tests in `test/index.test.ts` to build each case from shared provider fixtures.

## Testing

How you verified this (commands, scenarios, or N/A):

- [ ] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes** (or none)

none

**Risks / rollout** (or none)

Low risk refactor; behavior is intended to stay the same while the provider-specific logic is centralized.

**Focus areas for reviewers** (optional)

Provider URL generation and the updated matrix tests.

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes