### PR TITLE
test(index): add built entrypoint smoke test

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -115,6 +115,15 @@ describe('degit index', () => {
 	beforeEach(async () => await rimraf(indexTmp));
 	afterEach(async () => await rimraf(indexTmp));
 
+	it('exports a usable JS library from the built entrypoint', async () => {
+		const { default: builtDegit } = await import(new URL('../dist/index.js', import.meta.url).href);
+		const instance = builtDegit('Rich-Harris/degit-test-repo');
+
+		assert.equal(typeof builtDegit, 'function');
+		assert.equal(typeof instance.clone, 'function');
+		assert.equal(typeof instance.on, 'function');
+	});
+
 	describe('parser', () => {
 		providerCases.forEach((test) => {
 			it(`parsed repo fields match expected URLs when src targets ${test.site}`, () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -116,7 +116,9 @@ describe('degit index', () => {
 	afterEach(async () => await rimraf(indexTmp));
 
 	it('exports a usable JS library from the built entrypoint', async () => {
-		const { default: builtDegit } = await import(new URL('../dist/index.js', import.meta.url).href);
+		const { default: builtDegit } = await import(
+			new URL('../dist/index.js', import.meta.url).href
+		);
 		const instance = builtDegit('Rich-Harris/degit-test-repo');
 
 		assert.equal(typeof builtDegit, 'function');


### PR DESCRIPTION
## Summary

**What**

Add a smoke test that imports the built `dist/index.js` entrypoint and verifies the default export works as a JS library.

**Why**

The existing suite covered `src/index.js`, but not the published package entrypoint that consumers import from `dist/index.js`.

## Changes

- Added one Vitest case in `test/index.test.ts`.
- The test dynamically imports the built entrypoint and checks that `degit()` returns an object with `clone` and `on`.
- Kept the test deterministic and offline; it does not perform a real clone.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

Low risk; this is a read-only packaging smoke test.

**Focus areas for reviewers** (optional)

Built entrypoint import path and the asserted public API shape.

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
