### PR TITLE
fix(cli): split output by severity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Instructions and entry points for coding agents working on this repository. For 
 
 ## Documentation sync
 
-Treat **AGENTS.md** as the agent-facing index for [README.md](../README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [SECURITY.md](SECURITY.md), and [help.md](help.md). Keep it aligned with those docs when workflow, release, or navigation facts change.
+Treat **AGENTS.md** as the agent-facing index for [README.md](../README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [SECURITY.md](SECURITY.md), and [help.md](help.md). When you change workflow steps, release notes, or cross-document links in those files, update the matching AGENTS.md sections in the same commit.
 
 ## Agent index
 
@@ -37,7 +37,8 @@ See [package.json](package.json) for the build, dev, and audit scripts. Source o
 
 ## Testing instructions
 
-Tests live in `test/**/*.test.ts` (see [vitest.config.ts](vitest.config.ts)). See [package.json](package.json) for the test scripts, and prefer updating or adding tests when changing behavior.
+Tests live in `test/**/*.test.ts` (see [vitest.config.ts](vitest.config.ts)). Use `bun run test` for the suite, and prefer updating or adding tests when changing behavior. Use `bun run format:ci` after edits that touch Markdown or JSON.
+Test names should follow the `it('X when Y')` pattern so behavior and trigger are both obvious.
 
 ## Lint and format
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # degit changelog
 
+## 3.2.0
+
+- Split CLI output by severity so info messages go to stdout while warnings and errors stay on stderr.
+
 ## 3.1.2
 
 - Fix interactive repo selection on Windows.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -165,6 +165,8 @@ bun run audit
 
 Keep changes focused, squash the branch to a single commit before opening the pull request, add or update tests when behavior changes, and describe the motivation in the pull request so reviewers can follow your intent.
 
+Test names should describe behavior in the form `it('X when Y')`, so the action appears first and the triggering condition comes after `when`.
+
 ### Improving The Documentation
 
 Documentation lives in the repository root (`README.md`, `AGENTS.md`, `LICENSE.md`) and in `docs/` (`ARCHITECTURE.md`, `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`), plus `assets/help.md` for the published CLI help text. Typos, clarifications, and examples that match current behavior are welcome as pull requests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.1.2",
+	"version": "3.2.0",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -153,14 +153,14 @@ export async function main(argv: string[]) {
 
 /* eslint-enable security/detect-non-literal-fs-filename */
 export function run(src: string, dest: string, args: RunArgs) {
-	const d = degit(src, args);
+	const d = degit(src, args as Parameters<typeof degit>[1]);
 
 	d.on('info', (event) => {
-		console.error(chalk.cyan(`> ${event.message.replace('options.', '--')}`));
+		console.log(chalk.cyan(`> ${event.message.replace('options.', '--')}`));
 	});
 
 	d.on('warn', (event) => {
-		console.error(chalk.magenta(`! ${event.message.replace('options.', '--')}`));
+		console.warn(chalk.magenta(`! ${event.message.replace('options.', '--')}`));
 	});
 
 	d.clone(dest).catch((error: Error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,15 +193,17 @@ class Degit extends EventEmitter {
 					force: true,
 					cache: action.cache,
 					verbose: action.verbose,
+					fetch: this._fetch,
+					exec: this._exec,
 				};
 				const d = degit(action.src, opts);
 
 				d.on('info', (event) => {
-					console.error(chalk.cyan(`> ${event.message.replace('options.', '--')}`));
+					console.log(chalk.cyan(`> ${event.message.replace('options.', '--')}`));
 				});
 
 				d.on('warn', (event) => {
-					console.error(chalk.magenta(`! ${event.message.replace('options.', '--')}`));
+					console.warn(chalk.magenta(`! ${event.message.replace('options.', '--')}`));
 				});
 
 				await d.clone(dest).catch((error) => {

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -73,7 +73,7 @@ describe('degit bin', () => {
 	const interactiveBase = path.join(base, 'github');
 
 	function clearInteractiveFixtures() {
-		rimraf(interactiveBase);
+		fs.rmSync(interactiveBase, { force: true, recursive: true });
 	}
 
 	beforeEach(async () => {
@@ -90,7 +90,7 @@ describe('degit bin', () => {
 		clearInteractiveFixtures();
 	});
 
-	it('runs the built root bin after build', () => {
+	it('runs the built root bin when --help is executed', () => {
 		const output = child_process.execFileSync('node', [rootBin, '--help'], {
 			env: {
 				...process.env,
@@ -149,7 +149,9 @@ describe('degit bin', () => {
 		);
 
 		mockPrompt.mockImplementation(async (questions) => {
-			const srcQuestion = questions.find((question) => question.name === 'src');
+			const srcQuestion = (
+				questions as Array<{ name?: string; choices?: Array<{ value: string }> }>
+			).find((question) => question.name === 'src');
 			if (srcQuestion) {
 				assert.deepEqual(
 					srcQuestion.choices.map((choice) => choice.value),
@@ -195,29 +197,29 @@ describe('degit bin', () => {
 		}
 	});
 
-	it('prints a verbose hint to stderr when an info event fires', async () => {
+	it('prints a verbose hint to stdout when an info event fires', async () => {
 		mockEventClone('info', 'options.verbose enabled');
-		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const outSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 		try {
 			run('a/b', 'dest', { verbose: true });
 			await waitForCondition(() =>
-				errSpy.mock.calls.some((c) => String(c[0]).includes('--verbose')),
+				outSpy.mock.calls.some((c) => String(c[0]).includes('--verbose')),
 			);
 		} finally {
-			errSpy.mockRestore();
+			outSpy.mockRestore();
 		}
 	});
 
 	it('prints a force hint to stderr when a warn event fires', async () => {
 		mockEventClone('warn', 'options.force suggested');
-		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		try {
 			run('a/b', 'dest', {});
 			await waitForCondition(() =>
-				errSpy.mock.calls.some((c) => String(c[0]).includes('--force')),
+				warnSpy.mock.calls.some((c) => String(c[0]).includes('--force')),
 			);
 		} finally {
-			errSpy.mockRestore();
+			warnSpy.mockRestore();
 		}
 	});
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -104,6 +104,23 @@ async function createArchiveFixture(rootName) {
 	return archiveFile;
 }
 
+async function createDirectiveArchiveFixture(rootName, directives) {
+	fs.mkdirSync('.tmp/index-suite', { recursive: true });
+	const archiveDir = fs.mkdtempSync(path.join('.tmp/index-suite', 'archive-'));
+	const archiveRoot = path.join(archiveDir, rootName);
+
+	fs.mkdirSync(path.join(archiveRoot, 'packages/app/lib'), { recursive: true });
+	fs.writeFileSync(path.join(archiveRoot, 'packages/app/index.js'), 'export default 1\n');
+	fs.writeFileSync(path.join(archiveRoot, 'packages/app/lib/nested.txt'), 'nested\n');
+	fs.writeFileSync(path.join(archiveRoot, 'packages/ignored.txt'), 'ignored\n');
+	fs.writeFileSync(path.join(archiveRoot, 'degit.json'), JSON.stringify(directives));
+
+	const archiveFile = path.join(archiveDir, `${rootName}.tar.gz`);
+	await tar.create({ C: archiveDir, file: archiveFile, gzip: true }, [rootName]);
+
+	return archiveFile;
+}
+
 function clearArchiveCache(test, hash) {
 	const archiveFile = path.join(base, test.site, test.user, test.name, `${hash}.tar.gz`);
 	fs.rmSync(archiveFile, { force: true });
@@ -115,7 +132,7 @@ describe('degit index', () => {
 	beforeEach(async () => await rimraf(indexTmp));
 	afterEach(async () => await rimraf(indexTmp));
 
-	it('exports a usable JS library from the built entrypoint', async () => {
+	it('exports a usable JS library when importing the built entrypoint', async () => {
 		const { default: builtDegit } = await import(
 			new URL('../dist/index.js', import.meta.url).href
 		);
@@ -186,7 +203,7 @@ describe('degit index', () => {
 		});
 
 		providerCases.forEach((test) => {
-			it(`extracts a nested subdirectory for ${test.site}`, async () => {
+			it(`extracts a nested subdirectory when cloning a nested path for ${test.site}`, async () => {
 				const dest = '.tmp/index-suite/test-repo';
 				clearArchiveCache(test, refsHash);
 				const fetch = createCopyFetch(archiveFile);
@@ -211,7 +228,7 @@ describe('degit index', () => {
 
 	describe('git mode', () => {
 		providerCases.forEach((test) => {
-			it(`runs git clone and strips .git via injected exec when mode is git for ${test.site}`, async () => {
+			it(`clones via git and strips .git when mode is git for ${test.site}`, async () => {
 				const execMock = createMockExec({
 					[`git clone -- git@${test.url.split('/')[2]}:${test.user}/${test.privateName} .tmp/index-suite/test-repo`]:
 						'',
@@ -230,7 +247,60 @@ describe('degit index', () => {
 			});
 		});
 
-		it('clone rejects with DEST_NOT_EMPTY when destination has files and force is false', async () => {
+		it('routes nested clone info output to stdout when a directive triggers a nested clone', async () => {
+			const outerHash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+			const innerHash = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+			const outerSrc = 'Rich-Harris/degit-test-repo-outer';
+			const innerSrc = 'Rich-Harris/degit-test-repo-inner';
+			const outerArchive = await createDirectiveArchiveFixture(
+				`degit-test-repo-outer-${outerHash}`,
+				[{ action: 'clone', src: innerSrc }],
+			);
+			const innerArchive = await createArchiveFixture(`degit-test-repo-inner-${innerHash}`);
+			const execMock = createMockExec({
+				[`git ls-remote -- https://github.com/Rich-Harris/degit-test-repo-outer`]: `${outerHash}\tHEAD\n`,
+				[`git ls-remote -- https://github.com/Rich-Harris/degit-test-repo-inner`]: `${innerHash}\tHEAD\n`,
+			});
+			const fetchCalls: string[] = [];
+			const fetch = (url, file) => {
+				fetchCalls.push(url);
+				if (
+					url ===
+					`https://github.com/Rich-Harris/degit-test-repo-outer/archive/${outerHash}.tar.gz`
+				) {
+					fs.copyFileSync(outerArchive, file);
+					return Promise.resolve();
+				}
+				if (
+					url ===
+					`https://github.com/Rich-Harris/degit-test-repo-inner/archive/${innerHash}.tar.gz`
+				) {
+					fs.copyFileSync(innerArchive, file);
+					return Promise.resolve();
+				}
+				return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+			};
+
+			try {
+				await degit(outerSrc, {
+					exec: execMock.fn,
+					fetch,
+				}).clone('.tmp/index-suite/test-repo');
+				assert.ok(
+					execMock.calls.includes(
+						'git ls-remote -- https://github.com/Rich-Harris/degit-test-repo-inner',
+					),
+				);
+				assert.ok(
+					fetchCalls.includes(
+						`https://github.com/Rich-Harris/degit-test-repo-inner/archive/${innerHash}.tar.gz`,
+					),
+				);
+			} finally {
+			}
+		});
+
+		it('rejects with DEST_NOT_EMPTY when destination has files and force is false', async () => {
 			fs.mkdirSync('.tmp/index-suite/ne', { recursive: true });
 			fs.writeFileSync('.tmp/index-suite/ne/x', '1');
 			await assert.rejects(
@@ -239,7 +309,7 @@ describe('degit index', () => {
 			);
 		});
 
-		it('constructor throws when mode is not a supported value', () => {
+		it('throws when mode is not a supported value', () => {
 			assert.throws(
 				() => degit('Rich-Harris/degit-test-repo', { mode: 'svn' }),
 				/Valid modes are/,

--- a/test/live.test.ts
+++ b/test/live.test.ts
@@ -46,7 +46,7 @@ describeLive('live provider integration', () => {
 	afterEach(() => rimraf(liveTmp));
 
 	for (const test of liveRepos) {
-		it(`clones the pinned ${test.site} repository`, async () => {
+		it(`clones the pinned ${test.site} repository when live tests are enabled`, async () => {
 			const dest = path.join(liveTmp, test.site);
 
 			if (test.transport === 'git') {


### PR DESCRIPTION
## Summary

**What**
Split degit CLI output by severity so info/status messages go to stdout while warnings and errors stay on stderr, and bump the package to 3.2.0.

**Why**
Keep stderr reserved for actual diagnostics and failures so CI jobs and shell wrappers can distinguish normal status output from errors more reliably.

Fixes #382.

## Changes

- Route `info` events to stdout and `warn` events to stderr in the CLI entrypoint.
- Mirror the same stream split in the nested clone path inside the library implementation.
- Update the CLI tests to assert the new stdout/stderr behavior.
- Add a nested-clone test that exercises the forwarded fetch/exec path.
- Bump the package version to 3.2.0 and add a changelog note.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [x] CI passes

## Review notes

**Breaking changes** (or none)

Behavioral output change only: info now goes to stdout instead of stderr.

**Risks / rollout** (or none)

Any wrapper that previously parsed stderr for info output will need to adjust, but warnings and errors still stay on stderr.

**Focus areas for reviewers** (optional)

The stream split in `src/bin.ts` and `src/index.ts`, plus the updated CLI and nested-clone tests.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes