### PR TITLE
feat: add OS-aware cache resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v3.0%20adopted-ff69b4.svg)](docs/CODE_OF_CONDUCT.md)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 
-**degit** makes copies of git repositories. When you run `degit some-user/some-repo`, it will find the latest commit on https://github.com/some-user/some-repo and download the associated tar file to `~/.degit/some-user/some-repo/commithash.tar.gz` if it doesn't already exist locally. (This is much quicker than using `git clone`, because you're not downloading the entire git history.)
+**degit** makes copies of git repositories. When you run `degit some-user/some-repo`, it will find the latest commit on https://github.com/some-user/some-repo and download the associated tar file to the platform-appropriate cache directory if it doesn't already exist locally. On Linux/BSD this follows `XDG_CACHE_HOME` when set and otherwise uses `~/.cache/degit`; on macOS it uses `~/Library/Caches/degit`; on Windows it uses `%LOCALAPPDATA%\degit`. (This is much quicker than using `git clone`, because you're not downloading the entire git history.)
 
 ## Requirements
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,6 @@
         "enquirer": "2.3.6",
         "eslint-plugin-security": "4.0.0",
         "fuzzysearch": "1.0.3",
-        "home-or-tmp": "3.0.0",
         "https-proxy-agent": "5.0.0",
         "husky": "6.0.0",
         "jscpd": "4.0.9",
@@ -495,8 +494,6 @@
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
-
-    "home-or-tmp": ["home-or-tmp@3.0.0", "", {}, "sha512-pj6ktgQDedSIbzwrC108F9aZadnF2ZJ8mP8QbGq2nLPOmqpdqKWMoU4JPJaFEzpoTl6X/jOwE8BlkTOfVPR98A=="],
 
     "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ degit is a local CLI/library wrapper around remote repository snapshots:
 [User/CLI] -> [src/bin.ts] -> [src/index.ts]
 						   -> [src/utils.ts]
 						   -> [Remote provider tarball or git remote]
-						   -> [Local cache under ~/.degit]
+						   -> [Local cache under the platform cache directory]
 						   -> [Destination directory]
 ```
 
@@ -75,7 +75,7 @@ Name: Runtime helpers
 
 Description: Contains filesystem and process helpers used by the core flow. This includes the HTTPS fetch wrapper with proxy support, `git` command execution, recursive directory creation, local cache root detection, and stash/unstash helpers for directive processing.
 
-Technologies: Node `fs`, `path`, `https`, `child_process`, `home-or-tmp`, `https-proxy-agent`, `sander`
+Technologies: Node `fs`, `path`, `os`, `https`, `child_process`, `https-proxy-agent`, `sander`
 
 Deployment: Internal implementation detail, not exposed as a separate package.
 
@@ -107,7 +107,7 @@ The project does not use an application database or queue. Its persistent state 
 
 Name: degit cache
 
-Type: Filesystem cache under `~/.degit` with a home-or-tmp fallback
+Type: Filesystem cache under the platform-appropriate user cache directory
 
 Purpose: Stores downloaded tarballs and provider metadata so repeated clones can avoid refetching the same commit archive.
 
@@ -191,6 +191,6 @@ Git mode: The fallback mode that uses `git clone` over SSH, mainly for private r
 
 Directive: An entry in `degit.json` that runs after the initial clone. Current directives are `clone` and `remove`.
 
-Cache root: The local storage location at `~/.degit` (or the home-or-tmp fallback) used for downloaded archives and metadata.
+Cache root: The local storage location resolved from the platform cache directory used for downloaded archives and metadata.
 
 Provider: A supported hosting service whose repository URL format degit understands: GitHub, GitLab, Bitbucket, or Sourcehut.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # degit changelog
 
+## 3.3.0
+
+- Add platform-aware cache resolution so degit uses the standard user cache location on each supported OS.
+
 ## 3.2.0
 
 - Split CLI output by severity so info messages go to stdout while warnings and errors stay on stderr.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.2.0",
+	"version": "3.3.0",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",
@@ -51,7 +51,6 @@
 		"enquirer": "2.3.6",
 		"eslint-plugin-security": "4.0.0",
 		"fuzzysearch": "1.0.3",
-		"home-or-tmp": "3.0.0",
 		"https-proxy-agent": "5.0.0",
 		"husky": "6.0.0",
 		"jscpd": "4.0.9",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import homeOrTmp from 'home-or-tmp';
+import os from 'node:os';
 import https from 'node:https';
 import child_process from 'node:child_process';
 import * as URL from 'node:url';
@@ -19,6 +19,12 @@ type RequireOptions = {
 type ExecResult = {
 	stderr: string;
 	stdout: string;
+};
+
+type ResolveBaseOptions = {
+	env?: NodeJS.ProcessEnv;
+	homedir?: string;
+	platform?: NodeJS.Platform;
 };
 
 export { degitConfigName };
@@ -139,5 +145,21 @@ export function unstashFiles(dir: string, dest: string): void {
 	rimrafSync(tmpDir);
 }
 
+export function resolveBase({
+	env = process.env,
+	homedir = os.homedir(),
+	platform = process.platform,
+}: ResolveBaseOptions = {}): string {
+	if (platform === 'win32') {
+		return path.join(env.LOCALAPPDATA ?? path.join(homedir, 'AppData', 'Local'), 'degit');
+	}
+
+	if (platform === 'darwin') {
+		return path.join(homedir, 'Library', 'Caches', 'degit');
+	}
+
+	return path.join(env.XDG_CACHE_HOME ?? path.join(homedir, '.cache'), 'degit');
+}
+
 /* eslint-enable security/detect-non-literal-fs-filename */
-export const base = path.join(homeOrTmp, '.degit');
+export const base = resolveBase();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -121,9 +121,9 @@ async function createDirectiveArchiveFixture(rootName, directives) {
 	return archiveFile;
 }
 
-function clearArchiveCache(test, hash) {
-	const archiveFile = path.join(base, test.site, test.user, test.name, `${hash}.tar.gz`);
-	fs.rmSync(archiveFile, { force: true });
+function clearArchiveCache(test, _hash) {
+	const archiveDir = path.join(base, test.site, test.user, test.name);
+	fs.rmSync(archiveDir, { force: true, recursive: true });
 }
 
 describe('degit index', () => {
@@ -257,6 +257,14 @@ describe('degit index', () => {
 				[{ action: 'clone', src: innerSrc }],
 			);
 			const innerArchive = await createArchiveFixture(`degit-test-repo-inner-${innerHash}`);
+			fs.rmSync(path.join(base, 'github', 'Rich-Harris', 'degit-test-repo-outer'), {
+				force: true,
+				recursive: true,
+			});
+			fs.rmSync(path.join(base, 'github', 'Rich-Harris', 'degit-test-repo-inner'), {
+				force: true,
+				recursive: true,
+			});
 			const execMock = createMockExec({
 				[`git ls-remote -- https://github.com/Rich-Harris/degit-test-repo-outer`]: `${outerHash}\tHEAD\n`,
 				[`git ls-remote -- https://github.com/Rich-Harris/degit-test-repo-inner`]: `${innerHash}\tHEAD\n`,

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert';
+import path from 'node:path';
+import { describe, it } from 'vitest';
+import { resolveBase } from '../src/utils.js';
+
+describe('resolveBase', () => {
+	it('uses XDG_CACHE_HOME on linux when it is set', () => {
+		assert.equal(
+			resolveBase({
+				env: { XDG_CACHE_HOME: '/tmp/cache' },
+				homedir: '/home/user',
+				platform: 'linux',
+			}),
+			path.join('/tmp/cache', 'degit'),
+		);
+	});
+
+	it('falls back to the home cache directory on linux when XDG_CACHE_HOME is missing', () => {
+		assert.equal(
+			resolveBase({
+				env: {},
+				homedir: '/home/user',
+				platform: 'linux',
+			}),
+			path.join('/home/user', '.cache', 'degit'),
+		);
+	});
+
+	it('uses the macOS cache directory on darwin', () => {
+		assert.equal(
+			resolveBase({
+				env: { XDG_CACHE_HOME: '/tmp/cache' },
+				homedir: '/Users/user',
+				platform: 'darwin',
+			}),
+			path.join('/Users/user', 'Library', 'Caches', 'degit'),
+		);
+	});
+
+	it('uses LOCALAPPDATA on windows', () => {
+		assert.equal(
+			resolveBase({
+				env: { LOCALAPPDATA: 'C:/Users/user/AppData/Local' },
+				homedir: '/Users/user',
+				platform: 'win32',
+			}),
+			path.join('C:/Users/user/AppData/Local', 'degit'),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Issue #45: support XDG Base Directory Specification by resolving degit's cache root from the platform-appropriate user cache directory.

## Why

The cache path was hardcoded to `~/.degit`, which does not match native cache conventions on Linux/BSD, macOS, or Windows.

## Changes

- Added `resolveBase()` in `src/utils.ts` to choose the cache root from `XDG_CACHE_HOME`, macOS cache paths, or Windows AppData paths.
- Updated `README.md` and `docs/ARCHITECTURE.md` so the documented cache location matches the new behavior.
- Added direct resolver coverage in `test/utils.test.ts` and tightened cache cleanup in `test/index.test.ts` so the affected cache tests stay deterministic.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes**: none

**Risks / rollout**: Existing caches under `~/.degit` are not migrated; new clones will use the new platform-aware location.

**Focus areas for reviewers**: Cache root resolution in `src/utils.ts` and the related documentation updates.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
