### PR TITLE
refactor: remove unused degit state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ type RemoveDirective = Extract<Directive, { action: 'remove' }>;
 
 type DirectiveActions = {
 	clone: (dir: string, dest: string, action: CloneDirective) => Promise<void>;
-	remove: (dir: string, dest: string, action: RemoveDirective) => void;
+	remove: (dest: string, action: RemoveDirective) => void;
 };
 
 export type Options = ConstructorOptions;
@@ -151,7 +151,6 @@ export default function degit(src: string, opts: ConstructorOptions = {}) {
 }
 
 class Degit extends EventEmitter {
-	src: string;
 	cache?: boolean;
 	force?: boolean;
 	verbose?: boolean;
@@ -166,7 +165,6 @@ class Degit extends EventEmitter {
 	constructor(src: string, opts: ConstructorOptions = {}) {
 		super();
 
-		this.src = src;
 		this.cache = opts.cache;
 		this.force = opts.force;
 		this.verbose = opts.verbose;
@@ -211,7 +209,7 @@ class Degit extends EventEmitter {
 					process.exit(1);
 				});
 			},
-			remove: this.remove.bind(this),
+			remove: (dest, action) => this.remove(dest, action),
 		};
 	}
 
@@ -253,7 +251,7 @@ class Degit extends EventEmitter {
 				if (directive.action === 'clone') {
 					await this.directiveActions.clone(dir, dest, directive);
 				} else {
-					await this.directiveActions.remove(dir, dest, directive);
+					await this.directiveActions.remove(dest, directive);
 				}
 			}
 			if (this._hasStashed === true) {
@@ -263,7 +261,7 @@ class Degit extends EventEmitter {
 	}
 
 	/* eslint-disable security/detect-non-literal-fs-filename */
-	remove(dir: string, dest: string, action: RemoveDirective) {
+	remove(dest: string, action: RemoveDirective) {
 		let { files } = action;
 		if (!Array.isArray(files)) {
 			files = [files];


### PR DESCRIPTION
## Summary

**What**

Remove unused Degit instance state and trim internal directive plumbing.

**Why**

Reduce internal coupling and delete code that was not contributing to supported package behavior.

## Changes

- Removed the unused `src` field from the internal `Degit` class.
- Simplified the internal remove directive signature so it only passes the destination path it actually uses.
- Updated the nested directive call site to match the smaller internal API.

## Testing

How you verified this (commands, scenarios, or N/A):

- [ ] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

Focused verification:
- `bun test test/index.test.ts`

## Review notes

**Breaking changes** (or none)

None for supported package usage. This only removes unused internal state; code reaching into `instance.src` would be affected, but that was not a supported API.

**Risks / rollout** (or none)

Low. The change is internal and the focused index test suite passed.

**Focus areas for reviewers** (optional)

- Internal `Degit` class state and directive handling in `src/index.ts`

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
