### PR TITLE
fix: harden git-mode remote handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ A few salient differences:
 
 - If you `git clone`, you get a `.git` folder that pertains to the project template, rather than your project. You can easily forget to re-init the repository, and end up confusing yourself
 - Caching and offline support (if you already have a `.tar.gz` file for a specific commit, you don't need to fetch it again).
-- Less to type (`degit user/repo` instead of `git clone --depth 1 git@github.com:user/repo`)
+- Less to type (`degit user/repo` instead of `git clone --depth 1 ssh://git@github.com/user/repo`)
 - Composability via [actions](#actions)
 - Future capabilities — [interactive mode](https://github.com/Rich-Harris/degit/issues/4), [friendly onboarding and postinstall scripts](https://github.com/Rich-Harris/degit/issues/6)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # degit changelog
 
+## 3.3.1
+
+- Harden git-mode command execution and remote validation.
+
 ## 3.3.0
 
 - Add platform-aware cache resolution so degit uses the standard user cache location on each supported OS.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -522,7 +522,7 @@ function parse(src: string): Repo {
 
 	const domain = provider.domain;
 	const url = `https://${domain}/${user}/${name}`;
-	const ssh = `git@${domain}:${user}/${name}`;
+	const ssh = `ssh://git@${domain}/${user}/${name}`;
 
 	const mode = 'tar';
 
@@ -542,6 +542,16 @@ async function untar(file: string, dest: string, subdir: string | null = null): 
 
 async function fetchRefs(repo: Repo, runExec: ExecFn = exec) {
 	try {
+		const provider = getProvider(repo.site);
+		const remote = new URL(repo.url);
+
+		if (!provider || remote.protocol !== 'https:' || remote.hostname !== provider.domain) {
+			throw new DegitError(`could not fetch remote ${repo.url}`, {
+				code: 'COULD_NOT_FETCH',
+				url: repo.url,
+			});
+		}
+
 		const { stdout } = await runExec('git', ['ls-remote', '--', repo.url]);
 
 		return stdout

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -44,7 +44,7 @@ const providerCases = [
 			archiveUrl: (hash) => `${url}/archive/${hash}.tar.gz`,
 			gitSrc: `https://${domain}/${user}/${privateName}.git`,
 			lsRemote: `git ls-remote -- ${url}`,
-			ssh: `git@${domain}:${user}/${name}`,
+			ssh: `ssh://git@${domain}/${user}/${name}`,
 		}),
 	}),
 	createProviderCase({
@@ -57,7 +57,7 @@ const providerCases = [
 			archiveUrl: (hash) => `${url}/repository/archive.tar.gz?ref=${hash}`,
 			gitSrc: `gitlab:${user}/${privateName}`,
 			lsRemote: `git ls-remote -- ${url}`,
-			ssh: `git@${domain}:${user}/${name}`,
+			ssh: `ssh://git@${domain}/${user}/${name}`,
 		}),
 	}),
 	createProviderCase({
@@ -70,7 +70,7 @@ const providerCases = [
 			archiveUrl: (hash) => `${url}/get/${hash}.tar.gz`,
 			gitSrc: `bitbucket:${user}/${privateName}`,
 			lsRemote: `git ls-remote -- ${url}`,
-			ssh: `git@${domain}:${user}/${name}`,
+			ssh: `ssh://git@${domain}/${user}/${name}`,
 		}),
 	}),
 	createProviderCase({
@@ -83,7 +83,7 @@ const providerCases = [
 			archiveUrl: (hash) => `${url}/archive/${hash}.tar.gz`,
 			gitSrc: `git.sr.ht/${user}/${privateName}`,
 			lsRemote: `git ls-remote -- ${url}`,
-			ssh: `git@${domain}:${user}/${name}`,
+			ssh: `ssh://git@${domain}/${user}/${name}`,
 		}),
 	}),
 ];
@@ -230,7 +230,7 @@ describe('degit index', () => {
 		providerCases.forEach((test) => {
 			it(`clones via git and strips .git when mode is git for ${test.site}`, async () => {
 				const execMock = createMockExec({
-					[`git clone -- git@${test.url.split('/')[2]}:${test.user}/${test.privateName} .tmp/index-suite/test-repo`]:
+					[`git clone -- ssh://git@${test.url.split('/')[2]}/${test.user}/${test.privateName} .tmp/index-suite/test-repo`]:
 						'',
 					[`rm -rf ${path.resolve('.tmp/index-suite/test-repo', '.git')}`]: '',
 				});
@@ -241,7 +241,7 @@ describe('degit index', () => {
 				}).clone('.tmp/index-suite/test-repo');
 
 				assert.deepEqual(execMock.calls, [
-					`git clone -- git@${test.url.split('/')[2]}:${test.user}/${test.privateName} .tmp/index-suite/test-repo`,
+					`git clone -- ssh://git@${test.url.split('/')[2]}/${test.user}/${test.privateName} .tmp/index-suite/test-repo`,
 					`rm -rf ${path.resolve('.tmp/index-suite/test-repo', '.git')}`,
 				]);
 			});


### PR DESCRIPTION
## Summary

**What**

Harden git-mode remote handling and update the release metadata for the patch bump.

**Why**

Keep the git-mode path using a clearer SSH URL form and validate the remote before `git ls-remote` runs.

## Changes

- Switched git-mode SSH remotes to `ssh://git@...`.
- Added an explicit remote URL validation guard before fetching refs.
- Bumped the package version to `3.3.1`.
- Added a 3.3.1 changelog entry and updated the README example.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [x] CI passes

## Review notes

**Breaking changes** (or none)

None expected for supported usage.

**Risks / rollout** (or none)

Low risk. The change is limited to git-mode remote construction and ref lookup validation.

**Focus areas for reviewers** (optional)

Git-mode cloning and remote parsing.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
