### PR TITLE
refactor: split CLI and parser helpers

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -44,8 +44,8 @@ type RunArgs = {
 };
 
 /* eslint-disable security/detect-non-literal-fs-filename */
-export async function main(argv: string[]) {
-	const args = mri(argv.slice(2), {
+function parseCliArgs(argv: string[]) {
+	return mri(argv.slice(2), {
 		alias: {
 			c: 'cache',
 			f: 'force',
@@ -54,87 +54,105 @@ export async function main(argv: string[]) {
 		},
 		boolean: ['force', 'cache', 'verbose'],
 	}) as CliArgs;
+}
+
+function displayHelp() {
+	const help = fs
+		.readFileSync(path.join(__dirname, '..', 'assets', 'help.md'), 'utf8')
+		.replaceAll(/^(\s*)#+ (.+)/gm, (match, indent, title) => indent + chalk.bold(title))
+		.replaceAll(/_([^_]+)_/g, (match, value) => chalk.underline(value))
+		.replaceAll(/`([^`]+)`/g, (match, value) => chalk.cyan(value));
+
+	process.stdout.write(`\n${help}\n`);
+}
+
+function getInteractiveChoices(): Choice[] {
+	const accessLookup = new Map<string, number>();
+
+	glob('**/access.json', { cwd: base }).forEach((file) => {
+		const normalizedFile = file.replaceAll('\\', '/');
+		const [host, user, repo] = normalizedFile.split('/');
+		const json = fs.readFileSync(`${base}/${file}`, 'utf8');
+		const logs = JSON.parse(json) as Record<string, string | number>;
+
+		Object.entries(logs).forEach(([ref, timestamp]) => {
+			const id = `${host}:${user}/${repo}#${ref}`;
+			accessLookup.set(id, new Date(String(timestamp)).getTime());
+		});
+	});
+
+	const getChoices = (file: string): Choice[] => {
+		const normalizedFile = file.replaceAll('\\', '/');
+		const [host, user, repo] = normalizedFile.split('/');
+		const entries = Object.entries(tryRequire(`${base}/${file}`) || {});
+
+		return entries.map(([ref, hash]) => ({
+			message: `${host}:${user}/${repo}#${ref}`,
+			name: String(hash),
+			value: `${host}:${user}/${repo}#${ref}`,
+		}));
+	};
+
+	return glob('**/map.json', { cwd: base })
+		.flatMap(getChoices)
+		.sort((a, b) => (accessLookup.get(b.value) || 0) - (accessLookup.get(a.value) || 0));
+}
+
+async function promptForSource(): Promise<PromptResult> {
+	const sourcePrompt = {
+		choices: getInteractiveChoices(),
+		message: 'Repo to clone?',
+		name: 'src',
+		suggest: (input: string, promptChoices: Choice[]) =>
+			promptChoices.filter(({ value }) => fuzzysearch(input, value)),
+		type: 'autocomplete',
+	} as any;
+
+	return enquirer.prompt<PromptResult>([
+		sourcePrompt,
+		{
+			initial: '.',
+			message: 'Destination directory?',
+			name: 'dest',
+			type: 'input',
+		},
+		{
+			message: 'Use cached version?',
+			name: 'cache',
+			type: 'toggle',
+		},
+	] as any);
+}
+
+async function confirmOverwrite(): Promise<boolean> {
+	const { force } = await enquirer.prompt<ForceResult>([
+		{
+			message: 'Overwrite existing files?',
+			name: 'force',
+			type: 'toggle',
+		},
+	] as any);
+
+	return force;
+}
+
+export async function main(argv: string[]) {
+	const args = parseCliArgs(argv);
 
 	const [src, dest = '.'] = args._;
 
 	if (args.help) {
-		const help = fs
-			.readFileSync(path.join(__dirname, '..', 'assets', 'help.md'), 'utf8')
-			.replaceAll(/^(\s*)#+ (.+)/gm, (match, indent, title) => indent + chalk.bold(title))
-			.replaceAll(/_([^_]+)_/g, (match, value) => chalk.underline(value))
-			.replaceAll(/`([^`]+)`/g, (match, value) => chalk.cyan(value));
-
-		process.stdout.write(`\n${help}\n`);
+		displayHelp();
 		return;
 	}
 
 	if (!src) {
-		const accessLookup = new Map<string, number>();
-
-		glob('**/access.json', { cwd: base }).forEach((file) => {
-			const normalizedFile = file.replaceAll('\\', '/');
-			const [host, user, repo] = normalizedFile.split('/');
-			const json = fs.readFileSync(`${base}/${file}`, 'utf8');
-			const logs = JSON.parse(json) as Record<string, string | number>;
-
-			Object.entries(logs).forEach(([ref, timestamp]) => {
-				const id = `${host}:${user}/${repo}#${ref}`;
-				accessLookup.set(id, new Date(String(timestamp)).getTime());
-			});
-		});
-
-		const getChoices = (file: string): Choice[] => {
-			const normalizedFile = file.replaceAll('\\', '/');
-			const [host, user, repo] = normalizedFile.split('/');
-			const entries = Object.entries(tryRequire(`${base}/${file}`) || {});
-
-			return entries.map(([ref, hash]) => ({
-				message: `${host}:${user}/${repo}#${ref}`,
-				name: String(hash),
-				value: `${host}:${user}/${repo}#${ref}`,
-			}));
-		};
-
-		const choices = glob('**/map.json', { cwd: base })
-			.flatMap(getChoices)
-			.sort((a, b) => (accessLookup.get(b.value) || 0) - (accessLookup.get(a.value) || 0));
-
-		const sourcePrompt = {
-			choices,
-			message: 'Repo to clone?',
-			name: 'src',
-			suggest: (input: string, promptChoices: Choice[]) =>
-				promptChoices.filter(({ value }) => fuzzysearch(input, value)),
-			type: 'autocomplete',
-		} as any;
-
-		const options = await enquirer.prompt<PromptResult>([
-			sourcePrompt,
-			{
-				initial: '.',
-				message: 'Destination directory?',
-				name: 'dest',
-				type: 'input',
-			},
-			{
-				message: 'Use cached version?',
-				name: 'cache',
-				type: 'toggle',
-			},
-		] as any);
+		const options = await promptForSource();
 
 		const empty = !fs.existsSync(options.dest) || fs.readdirSync(options.dest).length === 0;
 
 		if (!empty) {
-			const { force } = await enquirer.prompt<ForceResult>([
-				{
-					message: 'Overwrite existing files?',
-					name: 'force',
-					type: 'toggle',
-				},
-			] as any);
-
-			if (!force) {
+			if (!(await confirmOverwrite())) {
 				console.error(chalk.magenta('! Directory not empty — aborting'));
 				return;
 			}

--- a/src/fetch-refs.ts
+++ b/src/fetch-refs.ts
@@ -1,0 +1,58 @@
+import { DegitError, exec } from './utils.js';
+import { getProvider, type Repo } from './repo.js';
+
+type ExecResult = {
+	stderr: string;
+	stdout: string;
+};
+
+type ExecFn = (command: string, args?: string[]) => Promise<ExecResult>;
+
+export async function fetchRefs(repo: Repo, runExec: ExecFn = exec) {
+	try {
+		const provider = getProvider(repo.site);
+		const remote = new URL(repo.url);
+
+		if (!provider || remote.protocol !== 'https:' || remote.hostname !== provider.domain) {
+			throw new DegitError(`could not fetch remote ${repo.url}`, {
+				code: 'COULD_NOT_FETCH',
+				url: repo.url,
+			});
+		}
+
+		const { stdout } = await runExec('git', ['ls-remote', '--', repo.url]);
+
+		return stdout
+			.split('\n')
+			.filter(Boolean)
+			.map((row) => {
+				const [hash, ref] = row.split('\t');
+
+				if (ref === 'HEAD') {
+					return {
+						hash,
+						type: 'HEAD',
+					};
+				}
+
+				const match = /refs\/(\w+)\/(.+)/.exec(ref);
+				if (!match) {
+					throw new DegitError(`could not parse ${ref}`, {
+						code: 'BAD_REF',
+					});
+				}
+
+				return {
+					hash,
+					name: match[2],
+					type: match[1] === 'heads' ? 'branch' : match[1] === 'refs' ? 'ref' : match[1],
+				};
+			});
+	} catch (error) {
+		throw new DegitError(`could not fetch remote ${repo.url}`, {
+			code: 'COULD_NOT_FETCH',
+			original: error,
+			url: repo.url,
+		});
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,26 +15,10 @@ import {
 	tryRequire,
 	unstashFiles,
 } from './utils.js';
+import { getProvider, parse, type Repo } from './repo.js';
+import { fetchRefs } from './fetch-refs.js';
 
 const validModes = new Set(['tar', 'git']);
-
-const supported = new Set(['github', 'gitlab', 'bitbucket', 'git.sr.ht']);
-
-type Provider = {
-	domain: string;
-	archiveUrl(repo: Repo, hash: string): string;
-};
-
-type Repo = {
-	mode: 'tar' | 'git';
-	name: string;
-	ref: string;
-	site: string;
-	ssh: string;
-	subdir?: string;
-	url: string;
-	user: string;
-};
 
 type ExecResult = {
 	stderr: string;
@@ -110,41 +94,6 @@ export type Info = EventInfo;
 export type Action = Directive;
 export type DegitAction = CloneDirective;
 export type RemoveAction = RemoveDirective;
-
-function getProvider(site: string): Provider | undefined {
-	switch (site) {
-		case 'github':
-			return {
-				domain: 'github.com',
-				archiveUrl(repo, hash) {
-					return `${repo.url}/archive/${hash}.tar.gz`;
-				},
-			};
-		case 'gitlab':
-			return {
-				domain: 'gitlab.com',
-				archiveUrl(repo, hash) {
-					return `${repo.url}/repository/archive.tar.gz?ref=${hash}`;
-				},
-			};
-		case 'bitbucket':
-			return {
-				domain: 'bitbucket.org',
-				archiveUrl(repo, hash) {
-					return `${repo.url}/get/${hash}.tar.gz`;
-				},
-			};
-		case 'git.sr.ht':
-			return {
-				domain: 'git.sr.ht',
-				archiveUrl(repo, hash) {
-					return `${repo.url}/archive/${hash}.tar.gz`;
-				},
-			};
-		default:
-			return undefined;
-	}
-}
 
 export default function degit(src: string, opts: ConstructorOptions = {}) {
 	return new Degit(src, opts);
@@ -467,70 +416,6 @@ class Degit extends EventEmitter {
 	}
 }
 
-function parse(src: string): Repo {
-	const [source, refValue = 'HEAD'] = src.split('#', 2);
-	let site = 'github';
-	let remainder = source;
-
-	if (source.startsWith('https://') || source.startsWith('http://')) {
-		const parsed = new URL(source);
-		site = parsed.hostname.replace(/\.(com|org)$/, '');
-		remainder = parsed.pathname.replace(/^\//, '');
-	} else if (source.startsWith('git@')) {
-		const match = /^git@([^:/]+)[:/](.+)$/.exec(source);
-		if (!match) {
-			throw new DegitError(`could not parse ${src}`, {
-				code: 'BAD_SRC',
-			});
-		}
-
-		site = match[1].replace(/\.(com|org)$/, '');
-		remainder = match[2];
-	} else if (source.startsWith('git.sr.ht/')) {
-		site = 'git.sr.ht';
-		remainder = source.slice('git.sr.ht/'.length);
-	} else {
-		const colonIndex = source.indexOf(':');
-		const slashIndex = source.indexOf('/');
-		if (colonIndex !== -1 && (slashIndex === -1 || colonIndex < slashIndex)) {
-			site = source.slice(0, colonIndex);
-			remainder = source.slice(colonIndex + 1);
-		}
-	}
-
-	if (!supported.has(site)) {
-		throw new DegitError(`degit supports GitHub, GitLab, Sourcehut and BitBucket`, {
-			code: 'UNSUPPORTED_HOST',
-		});
-	}
-
-	const provider = getProvider(site);
-	if (!provider) {
-		throw new DegitError(`degit supports GitHub, GitLab, Sourcehut and BitBucket`, {
-			code: 'UNSUPPORTED_HOST',
-		});
-	}
-
-	const [user, rawName, ...subdirParts] = remainder.split('/').filter(Boolean);
-	if (!user || !rawName) {
-		throw new DegitError(`could not parse ${src}`, {
-			code: 'BAD_SRC',
-		});
-	}
-
-	const name = rawName.replace(/\.git$/, '');
-	const subdir = subdirParts.length > 0 ? `/${subdirParts.join('/')}` : undefined;
-	const ref = refValue;
-
-	const domain = provider.domain;
-	const url = `https://${domain}/${user}/${name}`;
-	const ssh = `ssh://git@${domain}/${user}/${name}`;
-
-	const mode = 'tar';
-
-	return { mode, name, ref, site, ssh, subdir, url, user };
-}
-
 async function untar(file: string, dest: string, subdir: string | null = null): Promise<void> {
 	return tar.extract(
 		{
@@ -541,56 +426,6 @@ async function untar(file: string, dest: string, subdir: string | null = null): 
 		subdir ? [subdir] : [],
 	);
 }
-
-async function fetchRefs(repo: Repo, runExec: ExecFn = exec) {
-	try {
-		const provider = getProvider(repo.site);
-		const remote = new URL(repo.url);
-
-		if (!provider || remote.protocol !== 'https:' || remote.hostname !== provider.domain) {
-			throw new DegitError(`could not fetch remote ${repo.url}`, {
-				code: 'COULD_NOT_FETCH',
-				url: repo.url,
-			});
-		}
-
-		const { stdout } = await runExec('git', ['ls-remote', '--', repo.url]);
-
-		return stdout
-			.split('\n')
-			.filter(Boolean)
-			.map((row) => {
-				const [hash, ref] = row.split('\t');
-
-				if (ref === 'HEAD') {
-					return {
-						hash,
-						type: 'HEAD',
-					};
-				}
-
-				const match = /refs\/(\w+)\/(.+)/.exec(ref);
-				if (!match) {
-					throw new DegitError(`could not parse ${ref}`, {
-						code: 'BAD_REF',
-					});
-				}
-
-				return {
-					hash,
-					name: match[2],
-					type: match[1] === 'heads' ? 'branch' : match[1] === 'refs' ? 'ref' : match[1],
-				};
-			});
-	} catch (error) {
-		throw new DegitError(`could not fetch remote ${repo.url}`, {
-			code: 'COULD_NOT_FETCH',
-			original: error,
-			url: repo.url,
-		});
-	}
-}
-
 /* eslint-disable security/detect-non-literal-fs-filename, security/detect-possible-timing-attacks, security/detect-object-injection */
 function updateCache(dir: string, repo: Repo, hash: string, cached: Record<string, string>) {
 	// Update access logs

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -1,0 +1,118 @@
+import { DegitError } from './utils.js';
+
+type Provider = {
+	domain: string;
+	archiveUrl(repo: Repo, hash: string): string;
+};
+
+export type Repo = {
+	mode: 'tar' | 'git';
+	name: string;
+	ref: string;
+	site: string;
+	ssh: string;
+	subdir?: string;
+	url: string;
+	user: string;
+};
+
+const supported = new Set(['github', 'gitlab', 'bitbucket', 'git.sr.ht']);
+
+export function getProvider(site: string): Provider | undefined {
+	switch (site) {
+		case 'github':
+			return {
+				domain: 'github.com',
+				archiveUrl(repo, hash) {
+					return `${repo.url}/archive/${hash}.tar.gz`;
+				},
+			};
+		case 'gitlab':
+			return {
+				domain: 'gitlab.com',
+				archiveUrl(repo, hash) {
+					return `${repo.url}/repository/archive.tar.gz?ref=${hash}`;
+				},
+			};
+		case 'bitbucket':
+			return {
+				domain: 'bitbucket.org',
+				archiveUrl(repo, hash) {
+					return `${repo.url}/get/${hash}.tar.gz`;
+				},
+			};
+		case 'git.sr.ht':
+			return {
+				domain: 'git.sr.ht',
+				archiveUrl(repo, hash) {
+					return `${repo.url}/archive/${hash}.tar.gz`;
+				},
+			};
+		default:
+			return undefined;
+	}
+}
+
+export function parse(src: string): Repo {
+	const [source, refValue = 'HEAD'] = src.split('#', 2);
+	let site = 'github';
+	let remainder = source;
+
+	if (source.startsWith('https://') || source.startsWith('http://')) {
+		const parsed = new URL(source);
+		site = parsed.hostname.replace(/\.(com|org)$/, '');
+		remainder = parsed.pathname.replace(/^\//, '');
+	} else if (source.startsWith('git@')) {
+		const match = /^git@([^:/]+)[:/](.+)$/.exec(source);
+		if (!match) {
+			throw new DegitError(`could not parse ${src}`, {
+				code: 'BAD_SRC',
+			});
+		}
+
+		site = match[1].replace(/\.(com|org)$/, '');
+		remainder = match[2];
+	} else if (source.startsWith('git.sr.ht/')) {
+		site = 'git.sr.ht';
+		remainder = source.slice('git.sr.ht/'.length);
+	} else {
+		const colonIndex = source.indexOf(':');
+		const slashIndex = source.indexOf('/');
+		if (colonIndex !== -1 && (slashIndex === -1 || colonIndex < slashIndex)) {
+			site = source.slice(0, colonIndex);
+			remainder = source.slice(colonIndex + 1);
+		}
+	}
+
+	if (!supported.has(site)) {
+		throw new DegitError(`degit supports GitHub, GitLab, Sourcehut and BitBucket`, {
+			code: 'UNSUPPORTED_HOST',
+		});
+	}
+
+	const provider = getProvider(site);
+	if (!provider) {
+		throw new DegitError(`degit supports GitHub, GitLab, Sourcehut and BitBucket`, {
+			code: 'UNSUPPORTED_HOST',
+		});
+	}
+
+	const [user, rawName, ...subdirParts] = remainder.split('/').filter(Boolean);
+	if (!user || !rawName) {
+		throw new DegitError(`could not parse ${src}`, {
+			code: 'BAD_SRC',
+		});
+	}
+
+	const name = rawName.replace(/\.git$/, '');
+	const subdir = subdirParts.length > 0 ? `/${subdirParts.join('/')}` : undefined;
+	const ref = refValue;
+
+	const domain = provider.domain;
+	const url = `https://${domain}/${user}/${name}`;
+	const ssh = `ssh://git@${domain}/${user}/${name}`;
+
+	const mode = 'tar';
+
+	return { mode, name, ref, site, ssh, subdir, url, user };
+}


### PR DESCRIPTION
## Summary

**What**

Refactor the CLI and remote-resolution flow by extracting reusable helpers for argument parsing, prompt handling, repository parsing, and remote ref fetching.

**Why**

This keeps the main entry points smaller and isolates the network/ref lookup logic so the clone path is easier to follow and maintain.

## Changes

- Split CLI prompt/help logic in `src/bin.ts` into smaller helpers.
- Extract repository parsing and provider selection into `src/repo.ts`.
- Move remote ref fetching into `src/fetch-refs.ts` and route the clone flow through it.
- Keep the existing CLI behavior and prompt text intact while reorganizing the implementation.

## Testing

How you verified this (commands, scenarios, or N/A):

- [ ] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes**: none

**Risks / rollout**: low risk; this is an internal refactor with the same public CLI surface.

**Focus areas for reviewers**: the new `fetchRefs` error handling and the `repo.ts` parsing/provider split.

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
