### PR TITLE
chore: update husky to v9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+bunx lint-staged

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "eslint-plugin-security": "4.0.0",
         "fuzzysearch": "1.0.3",
         "https-proxy-agent": "5.0.0",
-        "husky": "6.0.0",
+        "husky": "9.1.7",
         "jscpd": "4.0.9",
         "knip": "6.11.0",
         "lint-staged": "10.5.4",
@@ -503,7 +503,7 @@
 
     "human-signals": ["human-signals@1.1.1", "", {}, "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="],
 
-    "husky": ["husky@6.0.0", "", { "bin": { "husky": "lib/bin.js" } }, "sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ=="],
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"lint:ci": "oxlint --import-plugin --deny-warnings .",
 		"audit": "bun audit",
 		"knip:ci": "knip",
+		"prepare": "husky",
 		"format": "oxfmt --write .",
 		"format:ci": "oxfmt --check .",
 		"duplicates:ci": "jscpd --gitignore --reporters console --threshold 5 tsdown.config.ts vitest.config.ts src test",
@@ -52,7 +53,7 @@
 		"eslint-plugin-security": "4.0.0",
 		"fuzzysearch": "1.0.3",
 		"https-proxy-agent": "5.0.0",
-		"husky": "6.0.0",
+		"husky": "9.1.7",
 		"jscpd": "4.0.9",
 		"knip": "6.11.0",
 		"lint-staged": "10.5.4",
@@ -67,11 +68,6 @@
 		"tsdown": "0.21.10",
 		"typescript": "6.0.3",
 		"vitest": "4.1.5"
-	},
-	"husky": {
-		"hooks": {
-			"pre-commit": "lint-staged"
-		}
 	},
 	"lint-staged": {
 		"*.{js,ts}": [


### PR DESCRIPTION
## Summary

**What**

Update Husky from v6 to v9 and migrate the repository to the current `.husky/pre-commit` + `prepare` setup.

**Why**

Keep the project aligned with Husky's current initialization flow while preserving pre-commit lint-staged checks.

## Changes

- Bump `husky` to `9.1.7`.
- Add `prepare: husky` so Husky initializes on install.
- Add `.husky/pre-commit` to run `bunx lint-staged`.
- Refresh `bun.lock` for the new dependency version.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [x] CI passes

## Review notes

**Breaking changes**

None.

**Risks / rollout**

Husky generates `.husky/_` helper files during install; those are expected and not committed.

**Focus areas for reviewers**

Pre-commit hook setup and the dependency/version update.

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
