### PR TITLE
fix: prevent first-time clone hangs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # degit changelog
 
+## 3.4.1
+
+- Fix first-clone hangs during archive downloads.
+
 ## 3.4.0
 
 - Tarball downloads are now the default, with SSH fallback on failure.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,8 +75,10 @@ export function fetch(url: string, dest: string, proxy?: string): Promise<void> 
 			.get(options, (response) => {
 				const code = response.statusCode;
 				if (code >= 400) {
+					response.resume();
 					reject({ code, message: response.statusMessage });
 				} else if (code >= 300) {
+					response.resume();
 					fetch(response.headers.location, dest, proxy).then(fulfil, reject);
 				} else {
 					response

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,7 +1,9 @@
+import fs from 'node:fs';
+import https from 'node:https';
 import assert from 'node:assert';
 import path from 'node:path';
-import { describe, it } from 'vitest';
-import { resolveBase } from '../../src/utils.js';
+import { describe, it, vi } from 'vitest';
+import { fetch, resolveBase } from '../../src/utils.js';
 
 describe('resolveBase', () => {
 	it('uses XDG_CACHE_HOME on linux when it is set', () => {
@@ -46,5 +48,51 @@ describe('resolveBase', () => {
 			}),
 			path.join('C:/Users/user/AppData/Local', 'degit'),
 		);
+	});
+
+	it('resumes redirect responses when following a redirected archive fetch', async () => {
+		const createWriteStreamSpy = vi.spyOn(fs, 'createWriteStream').mockReturnValue({
+			on(event: string, handler: () => void) {
+				if (event === 'finish') {
+					queueMicrotask(handler);
+				}
+
+				return this;
+			},
+		} as never);
+
+		const response1 = {
+			headers: { location: 'https://example.com/archive.tar.gz' },
+			pipe: vi.fn(),
+			resume: vi.fn(),
+			statusCode: 302,
+			statusMessage: 'Found',
+		};
+		const response2 = {
+			headers: {},
+			pipe: vi.fn((stream) => stream),
+			resume: vi.fn(),
+			statusCode: 200,
+			statusMessage: 'OK',
+		};
+
+		const getSpy = vi.spyOn(https, 'get').mockImplementation(((options, callback) => {
+			callback((getSpy.mock.calls.length === 1 ? response1 : response2) as never);
+			return {
+				on() {
+					return this;
+				},
+			};
+		}) as never);
+
+		try {
+			await fetch('https://example.com/archive.tar.gz', '/tmp/degit-fetch-test.tar.gz');
+			assert.equal(response1.resume.mock.calls.length, 1);
+			assert.equal(response2.resume.mock.calls.length, 0);
+			assert.equal(getSpy.mock.calls.length, 2);
+		} finally {
+			createWriteStreamSpy.mockRestore();
+			getSpy.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
## Summary

**What**

Fix first-time clone hangs by draining redirect and error responses during archive downloads.

**Why**

Cold-cache clones could leave the process alive after the success message because the HTTP response from archive fetches was not being drained.

## Changes

- Drain redirect and error responses in the archive download helper so sockets are released promptly.
- Add a regression test that verifies redirect responses are resumed before the next fetch continues.
- Bump the package patch version and record the fix in the changelog.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test test/unit/utils.test.ts`)
- [x] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

Low risk. The change only affects archive download response handling and does not alter clone results.

**Focus areas for reviewers** (optional)

The redirect/error handling in `src/utils.ts` and the regression test in `test/unit/utils.test.ts`.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes