### PR TITLE
fix: handle git-lfs pointer files

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # degit changelog
 
+## 3.4.2
+
+- Fix git-lfs pointer files falling through the tarball path.
+
 ## 3.4.1
 
 - Fix first-clone hangs during archive downloads.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.4.1",
+	"version": "3.4.2",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -414,6 +414,9 @@ class Degit extends EventEmitter {
 
 		const file = `${dir}/${hash}.tar.gz`;
 		const url = getProvider(repo.site).archiveUrl(repo, hash);
+		mkdirp(dir);
+		const extractedDir = fs.mkdtempSync(path.join(dir, 'extract-'));
+		let shouldFallbackToGit = false;
 
 		try {
 			if (!this.cache) {
@@ -442,21 +445,36 @@ class Degit extends EventEmitter {
 					await this._fetch(url, file, this.proxy);
 				}
 			}
+
+			this._verbose({
+				code: 'EXTRACTING',
+				message: `extracting ${subdir ? `${repo.subdir} from ` : ''}${file} to ${extractedDir}`,
+			});
+
+			await this._untarWithRetry(file, extractedDir, subdir, url);
+			shouldFallbackToGit = this._hasGitLfsPointers(extractedDir);
+
+			if (!shouldFallbackToGit) {
+				mkdirp(dest);
+				this._copyExtractedFiles(extractedDir, dest);
+			}
 		} catch (error) {
 			throw new DegitError(`could not download ${url}`, {
 				code: 'COULD_NOT_DOWNLOAD',
 				url,
 				original: error,
 			});
+		} finally {
+			rimrafSync(extractedDir);
 		}
 
-		this._verbose({
-			code: 'EXTRACTING',
-			message: `extracting ${subdir ? `${repo.subdir} from ` : ''}${file} to ${dest}`,
-		});
+		if (shouldFallbackToGit) {
+			this._warn({
+				message: `git lfs pointer detected in tar snapshot; falling back to git clone`,
+			});
+			await this._cloneWithGit(dest);
+		}
 
-		mkdirp(dest);
-		await this._untarWithRetry(file, dest, subdir, url);
 		updateCache(dir, repo, hash, cached);
 	}
 
@@ -490,6 +508,49 @@ class Degit extends EventEmitter {
 
 			await this._fetch(url, file, this.proxy);
 			await untar(file, dest, subdir);
+		}
+	}
+
+	_hasGitLfsPointers(dir: string): boolean {
+		// eslint-disable-next-line security/detect-non-literal-fs-filename
+		const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+		for (const entry of entries) {
+			const entryPath = path.join(dir, entry.name);
+
+			if (entry.isDirectory()) {
+				if (this._hasGitLfsPointers(entryPath)) {
+					return true;
+				}
+				continue;
+			}
+
+			if (!entry.isFile()) {
+				continue;
+			}
+
+			// eslint-disable-next-line security/detect-non-literal-fs-filename
+			const contents = fs.readFileSync(entryPath, 'utf8');
+			if (
+				/^version https:\/\/git-lfs\.github\.com\/spec\/v1$/m.test(contents) &&
+				/^oid sha256:[0-9a-f]{64}$/m.test(contents) &&
+				/^size \d+$/m.test(contents)
+			) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	_copyExtractedFiles(sourceDir: string, destDir: string) {
+		// eslint-disable-next-line security/detect-non-literal-fs-filename
+		const entries = fs.readdirSync(sourceDir, { withFileTypes: true });
+
+		for (const entry of entries) {
+			const sourcePath = path.join(sourceDir, entry.name);
+			const destinationPath = path.join(destDir, entry.name);
+			fs.cpSync(sourcePath, destinationPath, { recursive: true });
 		}
 	}
 }

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -106,6 +106,80 @@ async function createArchiveFixture(rootName) {
 	return archiveFile;
 }
 
+async function createArchiveWithFileFixture(rootName, relativePath, contents) {
+	fs.mkdirSync('.tmp/index-suite', { recursive: true });
+	const archiveDir = fs.mkdtempSync(path.join('.tmp/index-suite', 'archive-'));
+	const archiveRoot = path.join(archiveDir, rootName);
+
+	fs.mkdirSync(path.dirname(path.join(archiveRoot, relativePath)), { recursive: true });
+	fs.writeFileSync(path.join(archiveRoot, relativePath), contents);
+
+	const archiveFile = path.join(archiveDir, `${rootName}.tar.gz`);
+	await tar.create({ C: archiveDir, file: archiveFile, gzip: true }, [rootName]);
+
+	return archiveFile;
+}
+
+async function createArchiveWithGitLfsPointerFixture(rootName) {
+	return createArchiveWithFileFixture(
+		rootName,
+		'packages/app/asset.bin',
+		'version https://git-lfs.github.com/spec/v1\noid sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\nsize 1234\n',
+	);
+}
+
+async function cloneAndReadFile(test, archiveFile, dest, filePath, gitCloneOutput) {
+	const fetch = createCopyFetch(archiveFile);
+	const gitMock = createMockGit({
+		[`fetchRefs ${test.url}`]: gitRefs,
+		[`clone ${test.url} ${dest} HEAD`]: (_repo, cloneDest) => {
+			fs.mkdirSync(cloneDest, { recursive: true });
+			fs.writeFileSync(path.join(cloneDest, filePath), gitCloneOutput);
+		},
+	});
+
+	await degit(test.publicSrc, {
+		git: gitMock.fn,
+		fetch: fetch.fn,
+	}).clone(dest);
+
+	return { fetch, gitMock };
+}
+
+async function cloneAndExpectGitFallback(test, archiveFile, dest) {
+	const { fetch, gitMock } = await cloneAndReadFile(
+		test,
+		archiveFile,
+		dest,
+		'from-git.txt',
+		'git clone output\n',
+	);
+
+	assert.equal(fs.existsSync(path.join(dest, 'from-git.txt')), true);
+	assert.equal(fs.readFileSync(path.join(dest, 'from-git.txt'), 'utf8'), 'git clone output\n');
+	assert.equal(fetch.calls.length, 1);
+	assert.equal(fetch.calls[0].url, test.archiveUrl(refsHash));
+	assert.deepEqual(gitMock.calls, [`fetchRefs ${test.url}`, `clone ${test.url} ${dest} HEAD`]);
+}
+
+async function cloneAndExpectTarContent(test, archiveFile, dest, expectedPath, expectedContent) {
+	const fetch = createCopyFetch(archiveFile);
+	const gitMock = createMockGit({
+		[`fetchRefs ${test.url}`]: gitRefs,
+	});
+
+	await degit(test.publicSrc, {
+		git: gitMock.fn,
+		fetch: fetch.fn,
+	}).clone(dest);
+
+	assert.equal(fs.existsSync(path.join(dest, expectedPath)), true);
+	assert.equal(fs.readFileSync(path.join(dest, expectedPath), 'utf8'), expectedContent);
+	assert.equal(fetch.calls.length, 1);
+	assert.equal(fetch.calls[0].url, test.archiveUrl(refsHash));
+	assert.deepEqual(gitMock.calls, [`fetchRefs ${test.url}`]);
+}
+
 function clearArchiveCache(test, _hash) {
 	const archiveDir = path.join(base, test.site, test.user, test.name);
 	fs.rmSync(archiveDir, { force: true, recursive: true });
@@ -357,6 +431,32 @@ describe('degit index', () => {
 					`fetchRefs ${test.url}`,
 					`clone ${test.url} ${dest} ${refsHash}`,
 				]);
+			});
+		});
+
+		providerCases.forEach((test) => {
+			it(`does not fall back when a file merely quotes a pointer snippet for ${test.site}`, async () => {
+				const dest = '.tmp/index-suite/test-repo';
+				clearArchiveCache(test, refsHash);
+				const archiveFile = await createArchiveFixture(`degit-test-repo-${refsHash}`);
+				await cloneAndExpectTarContent(
+					test,
+					archiveFile,
+					dest,
+					'packages/app/index.js',
+					'export default 1\n',
+				);
+			});
+		});
+
+		providerCases.forEach((test) => {
+			it(`falls back to git clone when the tarball contains git-lfs pointers for ${test.site}`, async () => {
+				const dest = '.tmp/index-suite/test-repo';
+				clearArchiveCache(test, refsHash);
+				const archiveFile = await createArchiveWithGitLfsPointerFixture(
+					`degit-test-repo-${refsHash}`,
+				);
+				await cloneAndExpectGitFallback(test, archiveFile, dest);
 			});
 		});
 


### PR DESCRIPTION
## Summary

**What**

Handle git-lfs pointer files in tarball clones by extracting to a temp directory, detecting exact pointer files, and falling back to git clone when needed.

**Why**

Some repositories serve tarballs that contain Git LFS pointer files instead of real blob contents, so tarball-first cloning needs a fallback path for those repos.

resolved: #381

## Changes

- Extract tarballs into a temporary directory before copying files into the destination.
- Detect exact Git LFS pointer files, including the canonical and legacy Hawser pointer versions.
- Fall back to git clone only when a real pointer file is present.
- Keep the downloaded tarball cached and keep the warning when fallback happens.
- Add regression tests for quoted pointer text, canonical pointers, and legacy pointers.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [x] CI passes

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

The tarball path now scans extracted files before copying them into place.

**Focus areas for reviewers** (optional)

Tar extraction flow, pointer detection, and the regression coverage for pointer detection and fallback.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
