### PR TITLE
fix: make clone progress visible

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ type DirectiveActions = {
 export type Options = ConstructorOptions;
 export type ValidModes = 'tar' | 'git';
 export type InfoCode =
+	| 'CLONING'
 	| 'SUCCESS'
 	| 'FILE_DOES_NOT_EXIST'
 	| 'REMOVED'
@@ -188,57 +189,60 @@ class Degit extends EventEmitter {
 		this._checkDirIsEmpty(dest);
 
 		const { repo } = this;
+		const message = `cloned ${chalk.bold(repo.user + '/' + repo.name)}#${chalk.bold(repo.ref)}${dest !== '.' ? ` to ${dest}` : ''}`;
+
+		this._info({
+			code: 'CLONING',
+			dest,
+			message: `cloning ${chalk.bold(repo.user + '/' + repo.name)}#${chalk.bold(repo.ref)}${dest !== '.' ? ` to ${dest}` : ''}`,
+			repo,
+		});
 
 		if (this.mode === 'git') {
 			const hash = await this._getHash(repo, {});
 			await this._cloneWithGit(dest, hash || repo.ref);
-			this._info({
-				code: 'SUCCESS',
-				dest,
-				message: `cloned ${chalk.bold(repo.user + '/' + repo.name)}#${chalk.bold(repo.ref)}${dest !== '.' ? ` to ${dest}` : ''}`,
-				repo,
-			});
-			return;
 		}
 
-		const dir = path.join(base, repo.site, repo.user, repo.name);
+		if (this.mode !== 'git') {
+			const dir = path.join(base, repo.site, repo.user, repo.name);
 
-		try {
-			await this._cloneWithTar(dir, dest);
-		} catch (error) {
-			if (this._shouldFallbackToGit(error)) {
-				this._warn({
-					message: `tar snapshot download or extraction failed; falling back to git clone`,
-				});
-				await this._cloneWithGit(dest);
-			} else {
-				throw error;
+			try {
+				await this._cloneWithTar(dir, dest);
+			} catch (error) {
+				if (this._shouldFallbackToGit(error)) {
+					this._warn({
+						message: `tar snapshot download or extraction failed; falling back to git clone`,
+					});
+					await this._cloneWithGit(dest);
+				} else {
+					throw error;
+				}
+			}
+
+			const directives = this._getDirectives(dest);
+			if (directives) {
+				await directives.reduce(async (previous, directive) => {
+					await previous;
+
+					// TODO, can this be a loop with an index to pass for better error messages?
+					if (directive.action === 'clone') {
+						await this.directiveActions.clone(dir, dest, directive);
+					} else {
+						await this.directiveActions.remove(dest, directive);
+					}
+				}, Promise.resolve());
+				if (this._hasStashed === true) {
+					unstashFiles(dir, dest);
+				}
 			}
 		}
 
 		this._info({
 			code: 'SUCCESS',
 			dest,
-			message: `cloned ${chalk.bold(repo.user + '/' + repo.name)}#${chalk.bold(repo.ref)}${dest !== '.' ? ` to ${dest}` : ''}`,
+			message,
 			repo,
 		});
-
-		const directives = this._getDirectives(dest);
-		if (directives) {
-			await directives.reduce(async (previous, directive) => {
-				await previous;
-
-				// TODO, can this be a loop with an index to pass for better error messages?
-				if (directive.action === 'clone') {
-					await this.directiveActions.clone(dir, dest, directive);
-				} else {
-					await this.directiveActions.remove(dest, directive);
-				}
-			}, Promise.resolve());
-			if (this._hasStashed === true) {
-				unstashFiles(dir, dest);
-			}
-		}
 	}
 
 	/* eslint-disable security/detect-non-literal-fs-filename */

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -180,6 +180,24 @@ async function cloneAndExpectTarContent(test, archiveFile, dest, expectedPath, e
 	assert.deepEqual(gitMock.calls, [`fetchRefs ${test.url}`]);
 }
 
+async function createDirectiveArchive(rootName) {
+	fs.mkdirSync('.tmp/index-suite', { recursive: true });
+	const archiveDir = fs.mkdtempSync(path.join('.tmp/index-suite', 'archive-'));
+	const archiveRoot = path.join(archiveDir, rootName);
+
+	fs.mkdirSync(archiveRoot, { recursive: true });
+	fs.writeFileSync(
+		path.join(archiveRoot, 'degit.json'),
+		JSON.stringify([{ action: 'remove', files: 'remove-me.txt' }]),
+	);
+	fs.writeFileSync(path.join(archiveRoot, 'remove-me.txt'), 'remove me\n');
+
+	const archiveFile = path.join(archiveDir, `${rootName}.tar.gz`);
+	await tar.create({ C: archiveDir, file: archiveFile, gzip: true }, [rootName]);
+
+	return archiveFile;
+}
+
 function clearArchiveCache(test, _hash) {
 	const archiveDir = path.join(base, test.site, test.user, test.name);
 	fs.rmSync(archiveDir, { force: true, recursive: true });
@@ -484,6 +502,34 @@ describe('degit index', () => {
 				`fetchRefs ${test.url}`,
 				`clone ${test.url} ${dest} ${refsHash}`,
 			]);
+		});
+
+		it('emits cloning before success when tar mode finishes post-clone directives', async () => {
+			const test = providerCases[0];
+			const dest = '.tmp/index-suite/directive-order';
+			clearArchiveCache(test, refsHash);
+			const archiveFile = await createDirectiveArchive(`degit-test-repo-${refsHash}`);
+			const fetch = createCopyFetch(archiveFile);
+			const gitMock = createMockGit({
+				[`fetchRefs ${test.url}`]: gitRefs,
+			});
+			const events: string[] = [];
+
+			await degit(test.publicSrc, {
+				git: gitMock.fn,
+				fetch: fetch.fn,
+			})
+				.on('info', (event) => {
+					events.push(event.code ?? event.message);
+				})
+				.clone(dest);
+
+			assert.ok(events.includes('CLONING'));
+			assert.ok(events.includes('REMOVED'));
+			assert.ok(events.includes('SUCCESS'));
+			assert.ok(events.indexOf('CLONING') < events.indexOf('REMOVED'));
+			assert.ok(events.indexOf('REMOVED') < events.indexOf('SUCCESS'));
+			assert.equal(fs.existsSync(path.join(dest, 'remove-me.txt')), false);
 		});
 
 		it('rejects with DEST_NOT_EMPTY when destination has files and force is false', async () => {


### PR DESCRIPTION
## Summary

**What**

Make clone progress visible during long-running `degit` runs by emitting a `CLONING` lifecycle event before work starts and delaying `SUCCESS` until all tar/post-clone work is complete.

**Why**

Issue #220 reports that successful clones can look hung because the success line appears before the CLI is actually done.

## Changes

- Added a `CLONING` info event in `src/index.ts` so the CLI can show that work has started.
- Moved the `SUCCESS` emission to the end of the clone flow so it reflects completion after tar extraction and post-clone directives.
- Added a regression test in `test/unit/index.test.ts` that proves `CLONING` happens before directive cleanup and `SUCCESS`.

## Testing

How you verified this (commands, scenarios, or N/A):

- Focused unit tests: `bun run test test/unit/index.test.ts`
- Focused unit tests: `bun run test test/unit/bin.test.ts`
- CLI check: `node degit rollup/rollup rollup`

- [ ] Automated tests (`bun run test`)
- [x] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

The new start event is intentionally minimal; the main risk is only output-order expectations in consumers that were implicitly relying on the earlier success line.

**Focus areas for reviewers** (optional)

- `src/index.ts` lifecycle ordering
- `test/unit/index.test.ts` event-order regression coverage

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
