### PR TITLE
chore: migrate to yoctocolors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "devDependencies": {
         "@types/node": "25.6.0",
         "@vitest/coverage-v8": "4.1.5",
-        "chalk": "4.1.0",
         "enquirer": "2.3.6",
         "eslint-plugin-security": "4.0.0",
         "fuzzysearch": "1.0.3",
@@ -28,6 +27,7 @@
         "tsdown": "0.21.10",
         "typescript": "6.0.3",
         "vitest": "4.1.5",
+        "yoctocolors": "2.1.2",
       },
     },
   },
@@ -927,6 +927,8 @@
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
+
+    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,7 +61,7 @@ Name: CLI runner
 
 Description: Parses command-line arguments, renders help text, and provides an interactive repository picker when no source is supplied. It also wires the CLI to the core clone flow and prints colored status output to stderr.
 
-Technologies: TypeScript, `mri`, `enquirer`, `fuzzysearch`, `chalk`
+Technologies: TypeScript, `mri`, `enquirer`, `fuzzysearch`, `yoctocolors`
 
 Deployment: Built into the published `degit` executable and run locally via Node 20+ or Bun during development.
 
@@ -71,7 +71,7 @@ Name: Degit orchestrator
 
 Description: Implements the main clone lifecycle as an `EventEmitter`. It parses supported source formats, resolves refs, checks and uses the local cache, downloads tarballs, falls back to SSH cloning when tarball fetches or extraction fail, and applies `degit.json` directives after the initial clone.
 
-Technologies: TypeScript, `tar`, `sander`, `chalk`, Node standard library
+Technologies: TypeScript, `tar`, `sander`, `yoctocolors`, Node standard library
 
 Deployment: Bundled into the published library entrypoint and reused by the CLI and tests.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # degit changelog
 
+## 3.4.3
+
+- Swap terminal colors to yoctocolors.
+
 ## 3.4.2
 
 - Fix git-lfs pointer files falling through the tarball path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.4.2",
+	"version": "3.4.3",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",
@@ -52,7 +52,6 @@
 	"devDependencies": {
 		"@types/node": "25.6.0",
 		"@vitest/coverage-v8": "4.1.5",
-		"chalk": "4.1.0",
 		"enquirer": "2.3.6",
 		"eslint-plugin-security": "4.0.0",
 		"fuzzysearch": "1.0.3",
@@ -72,7 +71,8 @@
 		"tiny-glob": "0.2.8",
 		"tsdown": "0.21.10",
 		"typescript": "6.0.3",
-		"vitest": "4.1.5"
+		"vitest": "4.1.5",
+		"yoctocolors": "2.1.2"
 	},
 	"lint-staged": {
 		"*.{js,ts}": [

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import chalk from 'chalk';
+import colors from 'yoctocolors';
 import enquirer from 'enquirer';
 import fuzzysearch from 'fuzzysearch';
 import mri from 'mri';
@@ -59,9 +59,9 @@ function parseCliArgs(argv: string[]) {
 function displayHelp() {
 	const help = fs
 		.readFileSync(path.join(__dirname, '..', 'assets', 'help.md'), 'utf8')
-		.replaceAll(/^(\s*)#+ (.+)/gm, (match, indent, title) => indent + chalk.bold(title))
-		.replaceAll(/_([^_]+)_/g, (match, value) => chalk.underline(value))
-		.replaceAll(/`([^`]+)`/g, (match, value) => chalk.cyan(value));
+		.replaceAll(/^(\s*)#+ (.+)/gm, (match, indent, title) => indent + colors.bold(title))
+		.replaceAll(/_([^_]+)_/g, (match, value) => colors.underline(value))
+		.replaceAll(/`([^`]+)`/g, (match, value) => colors.cyan(value));
 
 	process.stdout.write(`\n${help}\n`);
 }
@@ -153,7 +153,7 @@ export async function main(argv: string[]) {
 
 		if (!empty) {
 			if (!(await confirmOverwrite())) {
-				console.error(chalk.magenta('! Directory not empty — aborting'));
+				console.error(colors.magenta('! Directory not empty — aborting'));
 				return;
 			}
 		}
@@ -173,15 +173,15 @@ export function run(src: string, dest: string, args: RunArgs) {
 	const d = degit(src, args as Parameters<typeof degit>[1]);
 
 	d.on('info', (event) => {
-		console.log(chalk.cyan(`> ${event.message.replace('options.', '--')}`));
+		console.log(colors.cyan(`> ${event.message.replace('options.', '--')}`));
 	});
 
 	d.on('warn', (event) => {
-		console.warn(chalk.magenta(`! ${event.message.replace('options.', '--')}`));
+		console.warn(colors.magenta(`! ${event.message.replace('options.', '--')}`));
 	});
 
 	d.clone(dest).catch((error: Error) => {
-		console.error(chalk.red(`! ${error.message.replace('options.', '--')}`));
+		console.error(colors.red(`! ${error.message.replace('options.', '--')}`));
 		process.exit(1);
 	});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import * as tar from 'tar';
 import EventEmitter from 'node:events';
-import chalk from 'chalk';
+import colors from 'yoctocolors';
 import { rimrafSync } from 'sander';
 import {
 	DegitError,
@@ -142,15 +142,15 @@ class Degit extends EventEmitter {
 				const d = degit(action.src, opts);
 
 				d.on('info', (event) => {
-					console.log(chalk.cyan(`> ${event.message.replace('options.', '--')}`));
+					console.log(colors.cyan(`> ${event.message.replace('options.', '--')}`));
 				});
 
 				d.on('warn', (event) => {
-					console.warn(chalk.magenta(`! ${event.message.replace('options.', '--')}`));
+					console.warn(colors.magenta(`! ${event.message.replace('options.', '--')}`));
 				});
 
 				await d.clone(dest).catch((error) => {
-					console.error(chalk.red(`! ${error.message}`));
+					console.error(colors.red(`! ${error.message}`));
 					process.exit(1);
 				});
 			},
@@ -195,7 +195,7 @@ class Degit extends EventEmitter {
 			this._info({
 				code: 'SUCCESS',
 				dest,
-				message: `cloned ${chalk.bold(repo.user + '/' + repo.name)}#${chalk.bold(repo.ref)}${dest !== '.' ? ` to ${dest}` : ''}`,
+				message: `cloned ${colors.bold(repo.user + '/' + repo.name)}#${colors.bold(repo.ref)}${dest !== '.' ? ` to ${dest}` : ''}`,
 				repo,
 			});
 			return;
@@ -219,7 +219,7 @@ class Degit extends EventEmitter {
 		this._info({
 			code: 'SUCCESS',
 			dest,
-			message: `cloned ${chalk.bold(repo.user + '/' + repo.name)}#${chalk.bold(repo.ref)}${dest !== '.' ? ` to ${dest}` : ''}`,
+			message: `cloned ${colors.bold(repo.user + '/' + repo.name)}#${colors.bold(repo.ref)}${dest !== '.' ? ` to ${dest}` : ''}`,
 			repo,
 		});
 
@@ -261,7 +261,7 @@ class Degit extends EventEmitter {
 				}
 				this._warn({
 					code: 'FILE_DOES_NOT_EXIST',
-					message: `action wants to remove ${chalk.bold(file)} but it does not exist`,
+					message: `action wants to remove ${colors.bold(file)} but it does not exist`,
 				});
 				return null;
 			})
@@ -270,7 +270,7 @@ class Degit extends EventEmitter {
 		if (removedFiles.length > 0) {
 			this._info({
 				code: 'REMOVED',
-				message: `removed: ${chalk.bold(removedFiles.map((d) => chalk.bold(d)).join(', '))}`,
+				message: `removed: ${colors.bold(removedFiles.map((d) => colors.bold(d)).join(', '))}`,
 			});
 		}
 	}


### PR DESCRIPTION
## Summary

**What**

Replace Chalk with Yoctocolors in the CLI and core logging paths, then update package metadata and docs to match.

**Why**

Shrink the runtime styling dependency surface without changing user-facing clone behavior.

## Changes

- Swapped the CLI help and status formatting in `src/bin.ts` from Chalk to Yoctocolors.
- Swapped the core clone/info/warn/error formatting in `src/index.ts` from Chalk to Yoctocolors.
- Updated `package.json`, `bun.lock`, and `docs/ARCHITECTURE.md` so the dependency and docs reflect the migration.
- This follows the original direction suggested in PR #380, but is updated for the current codebase and TypeScript source layout.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [x] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

`bun run build` passed. `bun run test` passed except for one unrelated existing failure in `test/unit/index.test.ts` for the GitHub HEAD-missing fallback path.

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

Low risk. The swap only touches terminal formatting and dependency metadata.

**Focus areas for reviewers** (optional)

Confirm the Yoctocolors import form and the updated docs/lockfile diff.

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes