### PR TITLE
refactor: remove sander dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,6 @@
         "oxfmt": "0.47.0",
         "oxlint": "1.62.0",
         "rimraf": "3.0.2",
-        "sander": "0.6.0",
         "source-map-support": "0.5.19",
         "tar": "7.5.11",
         "tiny-glob": "0.2.8",
@@ -676,8 +675,6 @@
 
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
-    "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
-
     "mri": ["mri@1.1.6", "", {}, "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -803,8 +800,6 @@
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-regex": ["safe-regex@2.1.1", "", { "dependencies": { "regexp-tree": "~0.1.1" } }, "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A=="],
-
-    "sander": ["sander@0.6.0", "", { "dependencies": { "graceful-fs": "^4.1.3", "mkdirp": "^0.5.1", "rimraf": "^2.5.2" } }, "sha512-5mA0zYqJ9aSiNQkvQLPObgt0TxYOWmOiavzNmt77jjyc6aFj3eqGsanxB6vnCACQWq6MVo3id4Uu6Eqiq2uh1g=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -961,8 +956,6 @@
     "rolldown-plugin-dts/@babel/parser": ["@babel/parser@8.0.0-rc.3", "", { "dependencies": { "@babel/types": "^8.0.0-rc.3" }, "bin": "./bin/babel-parser.js" }, "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ=="],
 
     "rolldown-plugin-dts/@babel/types": ["@babel/types@8.0.0-rc.3", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.3", "@babel/helper-validator-identifier": "^8.0.0-rc.3" } }, "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q=="],
-
-    "sander/rimraf": ["rimraf@2.7.1", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "./bin.js" } }, "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w=="],
 
     "@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.4", "", {}, "sha512-dluR3v287dp6YPF57kyKKrHPKffUeuxH1zQcF1WD30TeFzWXhDiVi1U6PkqaDB0++H1PeCwRhmYl4DvoerlPIw=="],
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,7 +71,7 @@ Name: Degit orchestrator
 
 Description: Implements the main clone lifecycle as an `EventEmitter`. It parses supported source formats, resolves refs, checks and uses the local cache, downloads tarballs, falls back to SSH cloning when tarball fetches or extraction fail, and applies `degit.json` directives after the initial clone.
 
-Technologies: TypeScript, `tar`, `sander`, `yoctocolors`, Node standard library
+Technologies: TypeScript, `tar`, `yoctocolors`, Node standard library
 
 Deployment: Bundled into the published library entrypoint and reused by the CLI and tests.
 
@@ -81,7 +81,7 @@ Name: Runtime helpers
 
 Description: Contains filesystem and process helpers used by the core flow. This includes the HTTPS fetch wrapper with proxy support, `git` command execution, recursive directory creation, local cache root detection, and stash/unstash helpers for directive processing.
 
-Technologies: Node `fs`, `path`, `os`, `https`, `child_process`, `https-proxy-agent`, `sander`
+Technologies: Node `fs`, `path`, `os`, `https`, `child_process`, `https-proxy-agent`
 
 Deployment: Internal implementation detail, not exposed as a separate package.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # degit changelog
 
+## 3.4.4
+
+- Remove the `sander` dependency in favor of native Node `fs` helpers.
+
 ## 3.4.3
 
 - Swap terminal colors to yoctocolors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.4.3",
+	"version": "3.4.4",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",
@@ -65,7 +65,6 @@
 		"oxfmt": "0.47.0",
 		"oxlint": "1.62.0",
 		"rimraf": "3.0.2",
-		"sander": "0.6.0",
 		"source-map-support": "0.5.19",
 		"tar": "7.5.11",
 		"tiny-glob": "0.2.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import * as tar from 'tar';
 import EventEmitter from 'node:events';
 import colors from 'yoctocolors';
-import { rimrafSync } from 'sander';
 import {
 	DegitError,
 	base,
@@ -253,7 +252,7 @@ class Degit extends EventEmitter {
 				if (fs.existsSync(filePath)) {
 					const isDir = fs.lstatSync(filePath).isDirectory();
 					if (isDir) {
-						rimrafSync(filePath);
+						fs.rmSync(filePath, { force: true, recursive: true });
 						return `${file}/`;
 					}
 					fs.unlinkSync(filePath);
@@ -465,7 +464,7 @@ class Degit extends EventEmitter {
 				original: error,
 			});
 		} finally {
-			rimrafSync(extractedDir);
+			fs.rmSync(extractedDir, { force: true, recursive: true });
 		}
 
 		if (shouldFallbackToGit) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,6 @@ import https from 'node:https';
 import * as URL from 'node:url';
 import { createRequire } from 'node:module';
 import Agent from 'https-proxy-agent';
-import { copydirSync, rimrafSync } from 'sander';
 
 const require = createRequire(import.meta.url);
 const tmpDirName = 'tmp';
@@ -93,15 +92,15 @@ export function fetch(url: string, dest: string, proxy?: string): Promise<void> 
 
 export function stashFiles(dir: string, dest: string): void {
 	const tmpDir = path.join(dir, tmpDirName);
-	rimrafSync(tmpDir);
+	fs.rmSync(tmpDir, { force: true, recursive: true });
 	mkdirp(tmpDir);
 	fs.readdirSync(dest).forEach((file) => {
 		const filePath = path.join(dest, file);
 		const targetPath = path.join(tmpDir, file);
 		const isDir = fs.lstatSync(filePath).isDirectory();
 		if (isDir) {
-			copydirSync(filePath).to(targetPath);
-			rimrafSync(filePath);
+			fs.cpSync(filePath, targetPath, { recursive: true });
+			fs.rmSync(filePath, { force: true, recursive: true });
 		} else {
 			fs.copyFileSync(filePath, targetPath);
 			fs.unlinkSync(filePath);
@@ -116,8 +115,8 @@ export function unstashFiles(dir: string, dest: string): void {
 		const targetPath = path.join(dest, filename);
 		const isDir = fs.lstatSync(tmpFile).isDirectory();
 		if (isDir) {
-			copydirSync(tmpFile).to(targetPath);
-			rimrafSync(tmpFile);
+			fs.cpSync(tmpFile, targetPath, { recursive: true });
+			fs.rmSync(tmpFile, { force: true, recursive: true });
 		} else {
 			if (filename !== 'degit.json') {
 				fs.copyFileSync(tmpFile, targetPath);
@@ -125,7 +124,7 @@ export function unstashFiles(dir: string, dest: string): void {
 			fs.unlinkSync(tmpFile);
 		}
 	});
-	rimrafSync(tmpDir);
+	fs.rmSync(tmpDir, { force: true, recursive: true });
 }
 
 export function resolveBase({

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -501,5 +501,23 @@ describe('degit index', () => {
 				/Valid modes are/,
 			);
 		});
+
+		it('removes nested directories recursively from the destination', () => {
+			const dest = fs.mkdtempSync(path.join(process.cwd(), 'remove-'));
+
+			try {
+				fs.mkdirSync(path.join(dest, 'nested', 'child'), { recursive: true });
+				fs.writeFileSync(path.join(dest, 'nested', 'child', 'file.txt'), 'nested\n');
+				fs.writeFileSync(path.join(dest, 'flat.txt'), 'flat\n');
+
+				const emitter = degit('Rich-Harris/degit-test-repo');
+				emitter.remove(dest, { files: ['nested', 'flat.txt'] });
+
+				assert.equal(fs.existsSync(path.join(dest, 'nested')), false);
+				assert.equal(fs.existsSync(path.join(dest, 'flat.txt')), false);
+			} finally {
+				fs.rmSync(dest, { force: true, recursive: true });
+			}
+		});
 	});
 });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -3,7 +3,7 @@ import https from 'node:https';
 import assert from 'node:assert';
 import path from 'node:path';
 import { describe, it, vi } from 'vitest';
-import { fetch, resolveBase } from '../../src/utils.js';
+import { fetch, resolveBase, stashFiles, unstashFiles } from '../../src/utils.js';
 
 describe('resolveBase', () => {
 	it('uses XDG_CACHE_HOME on linux when it is set', () => {
@@ -48,6 +48,43 @@ describe('resolveBase', () => {
 			}),
 			path.join('C:/Users/user/AppData/Local', 'degit'),
 		);
+	});
+
+	it('stashes and unstashes nested directories with degit.json excluded from restore', () => {
+		const root = fs.mkdtempSync(path.join(process.cwd(), 'stash-'));
+		const cacheDir = path.join(root, 'cache');
+		const dest = path.join(root, 'dest');
+
+		try {
+			fs.mkdirSync(path.join(dest, 'nested'), { recursive: true });
+			fs.writeFileSync(path.join(dest, 'nested', 'file.txt'), 'nested\n');
+			fs.writeFileSync(path.join(dest, 'top.txt'), 'top\n');
+			fs.writeFileSync(path.join(dest, 'degit.json'), 'outer directives\n');
+
+			stashFiles(cacheDir, dest);
+
+			assert.deepEqual(fs.readdirSync(dest), []);
+
+			fs.mkdirSync(path.join(dest, 'nested'), { recursive: true });
+			fs.writeFileSync(path.join(dest, 'nested', 'file.txt'), 'clone\n');
+			fs.writeFileSync(path.join(dest, 'top.txt'), 'clone top\n');
+			fs.writeFileSync(path.join(dest, 'degit.json'), 'clone directives\n');
+
+			unstashFiles(cacheDir, dest);
+
+			assert.equal(
+				fs.readFileSync(path.join(dest, 'nested', 'file.txt'), 'utf8'),
+				'nested\n',
+			);
+			assert.equal(fs.readFileSync(path.join(dest, 'top.txt'), 'utf8'), 'top\n');
+			assert.equal(
+				fs.readFileSync(path.join(dest, 'degit.json'), 'utf8'),
+				'clone directives\n',
+			);
+			assert.equal(fs.existsSync(path.join(cacheDir, 'tmp')), false);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
 	});
 
 	it('resumes redirect responses when following a redirected archive fetch', async () => {


### PR DESCRIPTION
## Summary

**What**

Remove `sander` from the runtime path by switching recursive copy/delete behavior to native Node `fs` APIs.

**Why**

The repo already targets Node 20+, so the native APIs are available and this removes an unnecessary dependency without changing the user-facing workflow.

Credit: this cleanup was originally explored in [PR #380](https://github.com/Rich-Harris/degit/pull/380); thanks for the foundation.

## Changes

- Replaced `sander` usage in `src/utils.ts` with `fs.cpSync` and `fs.rmSync` for stash/unstash handling.
- Replaced the remaining recursive cleanup calls in `src/index.ts` with `fs.rmSync`.
- Removed `sander` from package metadata and regenerated the lockfile.
- Updated `docs/ARCHITECTURE.md` to reflect the current runtime stack.
- Added focused unit coverage for recursive stash/restore and recursive removal behavior.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [x] CI passes

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

The main risk is behavior drift in the recursive stash/unstash path, since it preserves user files around git fallback. The added tests cover nested directories and `degit.json` restore behavior.

**Focus areas for reviewers** (optional)

Recursive filesystem behavior in `src/utils.ts` and the cleanup paths in `src/index.ts`.

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes