### PR TITLE
fix: stream ls-remote output

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # degit changelog
 
+## 3.4.5
+
+- Stream `git ls-remote` for SSH ref discovery.
+
 ## 3.4.4
 
 - Remove the `sander` dependency in favor of native Node `fs` helpers.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.4.4",
+	"version": "3.4.5",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",

--- a/src/git-client.ts
+++ b/src/git-client.ts
@@ -1,4 +1,4 @@
-import { execFile as execFileCallback } from 'node:child_process';
+import { execFile as execFileCallback, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -215,8 +215,43 @@ function getGitClonePlan(ref: string): GitPlan {
 }
 
 async function fetchRefsWithGitCli(repo: Repo) {
-	const { stdout } = await execFile('git', ['ls-remote', '--symref', getGitUrl(repo)]);
-	return parseGitLsRemoteOutput(stdout);
+	return new Promise<Ref[]>((resolve, reject) => {
+		const child = spawn('git', ['ls-remote', '--symref', getGitUrl(repo)], {
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+		const stdout = child.stdout;
+		const stderr = child.stderr;
+
+		if (!stdout || !stderr) {
+			reject(new Error('could not start git ls-remote'));
+			return;
+		}
+
+		let stdoutBuffer = '';
+		let stderrBuffer = '';
+
+		stdout.setEncoding('utf8');
+		stderr.setEncoding('utf8');
+		stdout.on('data', (chunk) => {
+			stdoutBuffer += chunk;
+		});
+		stderr.on('data', (chunk) => {
+			stderrBuffer += chunk;
+		});
+		child.once('error', reject);
+		child.once('close', (code) => {
+			if (code !== 0) {
+				const error = new Error(
+					stderrBuffer.trim() || `git ls-remote exited with code ${code}`,
+				);
+				(error as { code?: number | string }).code = code ?? 'GIT_LS_REMOTE_FAILED';
+				reject(error);
+				return;
+			}
+
+			resolve(parseGitLsRemoteOutput(stdoutBuffer));
+		});
+	});
 }
 
 async function fetchRefsWithIsomorphicGit(repo: Repo) {

--- a/test/unit/git-client.test.ts
+++ b/test/unit/git-client.test.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 import { vi } from 'vitest';
 
 const { getRemoteInfo2Mock, listServerRefsMock } = vi.hoisted(() => ({
@@ -6,6 +8,7 @@ const { getRemoteInfo2Mock, listServerRefsMock } = vi.hoisted(() => ({
 	listServerRefsMock: vi.fn(),
 }));
 
+const spawnMock = vi.hoisted(() => vi.fn());
 const execFileMock = vi.fn(
 	(command: string, _args: string[], callback: (error?: unknown) => void) => {
 		callback(
@@ -19,6 +22,7 @@ const execFileMock = vi.fn(
 
 vi.mock('node:child_process', () => ({
 	execFile: execFileMock,
+	spawn: spawnMock,
 }));
 
 vi.mock('isomorphic-git', () => ({
@@ -54,11 +58,50 @@ const httpsRepo = {
 	user: 'gitlab-org',
 } as const;
 
+function createSpawnProcess() {
+	const child = new EventEmitter() as EventEmitter & {
+		stderr: PassThrough;
+		stdout: PassThrough;
+	};
+
+	child.stdout = new PassThrough();
+	child.stderr = new PassThrough();
+
+	return child;
+}
+
+function writeChunkedLines(child: ReturnType<typeof createSpawnProcess>, lines: string[]) {
+	const chunkSize = 16;
+
+	for (let index = 0; index < lines.length; index += chunkSize) {
+		child.stdout.write(`${lines.slice(index, index + chunkSize).join('\n')}\n`);
+	}
+}
+
 describe('git client', () => {
 	beforeEach(() => {
 		execFileMock.mockClear();
+		spawnMock.mockClear();
 		getRemoteInfo2Mock.mockReset();
 		listServerRefsMock.mockReset();
+		spawnMock.mockImplementation((command: string, args: string[]) => {
+			if (command === 'git' && args[0] === 'ls-remote') {
+				const child = createSpawnProcess();
+				queueMicrotask(() => {
+					child.emit(
+						'error',
+						Object.assign(new Error(`spawn ${command} ENOENT`), {
+							code: 'ENOENT',
+							syscall: `spawn ${command}`,
+						}),
+					);
+				});
+
+				return child;
+			}
+
+			throw new Error(`Unexpected spawn call: ${command} ${args.join(' ')}`);
+		});
 		execFileMock.mockImplementation(
 			(command: string, args: string[], callback: (error?: unknown) => void) => {
 				if (command === 'git' && args[0] === 'clone') {
@@ -100,6 +143,45 @@ describe('git client', () => {
 		assert.equal(listServerRefsMock.mock.calls.length, 1);
 		assert.equal(getRemoteInfo2Mock.mock.calls.length, 1);
 		assert.equal(getRemoteInfo2Mock.mock.calls[0][0].protocolVersion, 1);
+	});
+
+	it('reads chunked ls-remote output when fetching refs over ssh', async () => {
+		spawnMock.mockImplementationOnce(() => {
+			const child = createSpawnProcess();
+			queueMicrotask(() => {
+				writeChunkedLines(child, [
+					'ref: refs/heads/main\tHEAD',
+					'0123456789abcdef0123456789abcdef01234567\trefs/heads/main',
+					...Array.from(
+						{ length: 99 },
+						(_value, index) =>
+							`0123456789abcdef0123456789abcdef012345${String(index).padStart(2, '0')}\trefs/heads/feature-${index}`,
+					),
+				]);
+				child.stderr.end();
+				child.emit('close', 0);
+			});
+
+			return child;
+		});
+
+		const refs = await createGitClient().fetchRefs(sshRepo);
+
+		assert.equal(refs.length, 101);
+		assert.deepEqual(refs[0], {
+			hash: '0123456789abcdef0123456789abcdef01234567',
+			name: 'main',
+			type: 'branch',
+		});
+		assert.deepEqual(refs[50], {
+			hash: '0123456789abcdef0123456789abcdef01234549',
+			name: 'feature-49',
+			type: 'branch',
+		});
+		assert.deepEqual(refs[100], {
+			hash: '0123456789abcdef0123456789abcdef01234567',
+			type: 'HEAD',
+		});
 	});
 
 	it('reports a missing git binary when fetching refs over ssh', async () => {


### PR DESCRIPTION
## Summary

**What**

Stream SSH `git ls-remote` output instead of buffering it.

**Why**

Large remotes could exceed Node's buffered exec limit before ref discovery finished.

- Credit: thanks to [PR #360](https://github.com/Rich-Harris/degit/pull/360) for surfacing the issue.

## Changes

- Replaced the SSH ref-discovery path in `src/git-client.ts` with a streaming `spawn` helper.
- Kept the existing ref parser and error handling intact.
- Added a regression test for chunked `ls-remote` output in `test/unit/git-client.test.ts`.
- Added a short release note in `docs/CHANGELOG.md` and bumped the patch version in `package.json`.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [x] CI passes

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

Spawn changes the child-process path for SSH ref discovery, but the existing error mapping and clone fallback stay the same.

**Focus areas for reviewers** (optional)

`src/git-client.ts` and `test/unit/git-client.test.ts`.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes