### PR TITLE
fix: block remove path traversal outside destination

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # degit changelog
 
+## 3.4.6
+
+- Block `remove` path traversal outside the destination.
+
 ## 3.4.5
 
 - Stream `git ls-remote` for SSH ref discovery.
@@ -59,6 +63,10 @@
 
 - Major release for the Node 20+ line; v2 remains the legacy Node 8-compatible branch.
 - Upgrade `tar` to a patched release to address the security issue that affected the previous dependency.
+
+## 2.8.6
+
+- Harden git-mode command execution and remote validation.
 
 ## 2.8.5
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.4.5",
+	"version": "3.4.6",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export type ValidModes = 'tar' | 'git';
 export type InfoCode =
 	| 'SUCCESS'
 	| 'FILE_DOES_NOT_EXIST'
+	| 'FILE_OUTSIDE_DEST'
 	| 'REMOVED'
 	| 'DEST_NOT_EMPTY'
 	| 'DEST_IS_EMPTY'
@@ -246,9 +247,18 @@ class Degit extends EventEmitter {
 		if (!Array.isArray(files)) {
 			files = [files];
 		}
+		const root = path.resolve(dest);
 		const removedFiles = files
 			.map((file) => {
-				const filePath = path.resolve(dest, file);
+				const filePath = path.resolve(root, file);
+				const relativePath = path.relative(root, filePath);
+				if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+					this._warn({
+						code: 'FILE_OUTSIDE_DEST',
+						message: `action wants to remove ${colors.bold(file)} but it is outside the destination, skipping`,
+					});
+					return null;
+				}
 				if (fs.existsSync(filePath)) {
 					const isDir = fs.lstatSync(filePath).isDirectory();
 					if (isDir) {

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -525,5 +525,33 @@ describe('degit index', () => {
 				fs.rmSync(dest, { force: true, recursive: true });
 			}
 		});
+
+		it('warns and skips paths that escape the destination when removing files', () => {
+			const workspace = fs.mkdtempSync(path.join(process.cwd(), 'remove-'));
+			const dest = path.join(workspace, 'dest');
+			const sibling = path.join(workspace, 'sibling');
+			const warnings: string[] = [];
+
+			try {
+				fs.mkdirSync(dest, { recursive: true });
+				fs.mkdirSync(sibling, { recursive: true });
+				fs.writeFileSync(path.join(sibling, 'secret.txt'), 'secret\n');
+
+				const emitter = degit('Rich-Harris/degit-test-repo');
+				emitter.on('warn', (event) => warnings.push(event.message));
+
+				emitter.remove(dest, { files: ['../sibling'] });
+
+				assert.equal(fs.existsSync(path.join(sibling, 'secret.txt')), true);
+				assert.equal(warnings.length, 1);
+				assert.match(
+					warnings[0],
+					/action wants to remove .*outside the destination, skipping/,
+				);
+				assert.match(warnings[0], /\.\.\/sibling/);
+			} finally {
+				fs.rmSync(workspace, { force: true, recursive: true });
+			}
+		});
 	});
 });


### PR DESCRIPTION
## Summary

**What**
Prevent `remove` from traversing outside the destination directory.

**Why**
This blocks accidental or malicious deletes outside the target tree.

## Changes

- Normalize the destination root before resolving remove targets.
- Skip and warn when a requested path resolves outside the destination.
- Add coverage for the escape-path case.
- Bump the package version and record the release note.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [x] CI passes

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

Low risk. The change only skips remove requests that resolve outside the destination and emits a warning instead of deleting anything.

**Focus areas for reviewers** (optional)

- `src/index.ts` path resolution and warning behavior
- `test/unit/index.test.ts` coverage for escaped remove paths

## Checklist

- [x] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes