### PR TITLE
feat: gate clone error details behind verbose

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -182,8 +182,42 @@ export function run(src: string, dest: string, args: RunArgs) {
 
 	d.clone(dest).catch((error: Error) => {
 		console.error(colors.red(`! ${error.message.replace('options.', '--')}`));
+		if (args.verbose) {
+			const detail = getCloneErrorDetail(error);
+
+			if (detail) {
+				console.error(detail);
+			}
+		}
 		process.exit(1);
 	});
+}
+
+function getCloneErrorDetail(error: unknown): string | undefined {
+	if (!error || typeof error !== 'object') {
+		return undefined;
+	}
+
+	const nestedError =
+		'original' in error ? error.original : 'cause' in error ? error.cause : undefined;
+
+	if (!nestedError) {
+		return undefined;
+	}
+
+	if (nestedError instanceof Error) {
+		return nestedError.stack || nestedError.message;
+	}
+
+	if (typeof nestedError === 'string') {
+		return nestedError;
+	}
+
+	try {
+		return JSON.stringify(nestedError);
+	} catch {
+		return String(nestedError);
+	}
 }
 
 if (!process.env.VITEST) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,6 +188,7 @@ class Degit extends EventEmitter {
 		this._checkDirIsEmpty(dest);
 
 		const { repo } = this;
+		const successMessage = cloneSuccessMessage(repo.user, repo.name, repo.ref, dest);
 
 		if (this.mode === 'git') {
 			const hash = await this._getHash(repo, {});
@@ -195,7 +196,7 @@ class Degit extends EventEmitter {
 			this._info({
 				code: 'SUCCESS',
 				dest,
-				message: `cloned ${colors.bold(repo.user + '/' + repo.name)}#${colors.bold(repo.ref)}${dest !== '.' ? ` to ${dest}` : ''}`,
+				message: successMessage,
 				repo,
 			});
 			return;
@@ -219,7 +220,7 @@ class Degit extends EventEmitter {
 		this._info({
 			code: 'SUCCESS',
 			dest,
-			message: `cloned ${colors.bold(repo.user + '/' + repo.name)}#${colors.bold(repo.ref)}${dest !== '.' ? ` to ${dest}` : ''}`,
+			message: successMessage,
 			repo,
 		});
 
@@ -562,6 +563,10 @@ class Degit extends EventEmitter {
 			fs.cpSync(sourcePath, destinationPath, { recursive: true });
 		}
 	}
+}
+
+function cloneSuccessMessage(user: string, name: string, ref: string, dest: string) {
+	return `cloned ${colors.bold(user + '/' + name)}#${colors.bold(ref)}${dest !== '.' ? ` to ${dest}` : ''}`;
 }
 
 async function untar(file: string, dest: string, subdir: string | null = null): Promise<void> {

--- a/test/unit/bin.test.ts
+++ b/test/unit/bin.test.ts
@@ -73,6 +73,30 @@ function mockEventClone(eventName, message) {
 	return handlers;
 }
 
+async function withCloneFailure(
+	args: Parameters<typeof run>[2],
+	error: Error,
+	assertions: (exitSpy: ReturnType<typeof vi.spyOn>, errSpy: ReturnType<typeof vi.spyOn>) => void,
+) {
+	mockDegit.mockReturnValue({
+		clone: vi.fn().mockReturnValue(Promise.reject(error)),
+		on: vi.fn().mockReturnThis(),
+	} as never);
+
+	const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+	const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+	try {
+		run('a/b', 'dest', args);
+		await waitForCondition(() => exitSpy.mock.calls.length > 0);
+		assert.equal(exitSpy.mock.calls[0][0], 1);
+		assertions(exitSpy, errSpy);
+	} finally {
+		exitSpy.mockRestore();
+		errSpy.mockRestore();
+	}
+}
+
 describe('degit bin', () => {
 	const binTmp = '.tmp/bin-suite';
 	const repoRoot = process.cwd();
@@ -188,21 +212,34 @@ describe('degit bin', () => {
 	});
 
 	it('exits with status 1 when the clone promise rejects', async () => {
-		const err = new Error('clone failed');
-		mockDegit.mockReturnValue({
-			clone: vi.fn().mockReturnValue(Promise.reject(err)),
-			on: vi.fn().mockReturnThis(),
-		} as never);
-		const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
-		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-		try {
-			run('a/b', 'dest', { force: true });
-			await waitForCondition(() => exitSpy.mock.calls.length > 0);
-			assert.equal(exitSpy.mock.calls[0][0], 1);
-		} finally {
-			exitSpy.mockRestore();
-			errSpy.mockRestore();
-		}
+		const err = Object.assign(new Error('clone failed'), { original: 'nested failure' });
+
+		await withCloneFailure({ force: true }, err, (_exitSpy, errSpy) => {
+			assert.equal(errSpy.mock.calls.length, 1);
+			assert.ok(String(errSpy.mock.calls[0][0]).includes('clone failed'));
+			assert.ok(!String(errSpy.mock.calls[0][0]).includes('nested failure'));
+		});
+	});
+
+	it('prints nested clone failure details when verbose mode is enabled', async () => {
+		const err = Object.assign(new Error('clone failed'), { original: 'nested failure' });
+
+		await withCloneFailure({ force: true, verbose: true }, err, (_exitSpy, errSpy) => {
+			assert.equal(errSpy.mock.calls.length, 2);
+			assert.ok(String(errSpy.mock.calls[0][0]).includes('clone failed'));
+			assert.ok(String(errSpy.mock.calls[1][0]).includes('nested failure'));
+		});
+	});
+
+	it('keeps verbose clone failures stable when nested details are missing', async () => {
+		await withCloneFailure(
+			{ force: true, verbose: true },
+			new Error('clone failed'),
+			(_exitSpy, errSpy) => {
+				assert.equal(errSpy.mock.calls.length, 1);
+				assert.ok(String(errSpy.mock.calls[0][0]).includes('clone failed'));
+			},
+		);
 	});
 
 	it('prints a verbose hint to stdout when an info event fires', async () => {

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -96,10 +96,16 @@ const providerCases = [
 	}),
 ];
 
-async function createArchiveFixture(rootName) {
+function createArchiveRootFixture(rootName) {
 	fs.mkdirSync('.tmp/index-suite', { recursive: true });
 	const archiveDir = fs.mkdtempSync(path.join('.tmp/index-suite', 'archive-'));
 	const archiveRoot = path.join(archiveDir, rootName);
+
+	return { archiveDir, archiveRoot };
+}
+
+async function createArchiveFixture(rootName) {
+	const { archiveDir, archiveRoot } = createArchiveRootFixture(rootName);
 
 	fs.mkdirSync(path.join(archiveRoot, 'packages/app/lib'), { recursive: true });
 	fs.writeFileSync(path.join(archiveRoot, 'packages/app/index.js'), 'export default 1\n');
@@ -113,9 +119,7 @@ async function createArchiveFixture(rootName) {
 }
 
 async function createArchiveWithFileFixture(rootName, relativePath, contents) {
-	fs.mkdirSync('.tmp/index-suite', { recursive: true });
-	const archiveDir = fs.mkdtempSync(path.join('.tmp/index-suite', 'archive-'));
-	const archiveRoot = path.join(archiveDir, rootName);
+	const { archiveDir, archiveRoot } = createArchiveRootFixture(rootName);
 
 	fs.mkdirSync(path.dirname(path.join(archiveRoot, relativePath)), { recursive: true });
 	fs.writeFileSync(path.join(archiveRoot, relativePath), contents);


### PR DESCRIPTION
## Summary

**What**

Gate clone failure diagnostics behind `--verbose` so normal CLI output stays terse while users can opt into nested error details when needed.

**Why**

Improve debugging for clone failures without making the default output noisier.

## Changes

- Added verbose-gated clone failure logging in `src/bin.ts`.
- Kept the existing top-level red error line unchanged.
- Added a safe helper for nested error details that tolerates missing `original` / `cause` fields.
- Added unit coverage for default, verbose, and missing-nested-detail failure paths in `test/unit/bin.test.ts`.
- Follow-up to the original discussion in #366.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [x] CI passes

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

Verbose output now depends on the shape of nested error objects, but the helper falls back safely when those fields are absent.

**Focus areas for reviewers** (optional)

- `src/bin.ts` error handling
- `test/unit/bin.test.ts` coverage for clone failure output

## Checklist

- [x] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
