### PR TITLE
refactor(tar): remove fs-extra dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,12 +5,10 @@
     "": {
       "name": "degit",
       "devDependencies": {
-        "@types/fs-extra": "11.0.4",
         "@types/node": "25.6.0",
         "@vitest/coverage-v8": "4.1.8",
         "enquirer": "2.3.6",
         "eslint-plugin-security": "4.0.0",
-        "fs-extra": "11.3.5",
         "fuzzysearch": "1.0.3",
         "https-proxy-agent": "5.0.0",
         "husky": "9.1.7",
@@ -290,11 +288,7 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/fs-extra": ["@types/fs-extra@11.0.4", "", { "dependencies": { "@types/jsonfile": "*", "@types/node": "*" } }, "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ=="],
-
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
-
-    "@types/jsonfile": ["@types/jsonfile@6.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
@@ -490,7 +484,7 @@
 
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
-    "fs-extra": ["fs-extra@11.3.5", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg=="],
+    "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
@@ -942,19 +936,9 @@
 
     "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
-    "@jscpd/badge-reporter/fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
-
-    "@jscpd/finder/fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
-
-    "@jscpd/html-reporter/fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
-
     "ast-kit/@babel/parser": ["@babel/parser@8.0.0-rc.3", "", { "dependencies": { "@babel/types": "^8.0.0-rc.3" }, "bin": "./bin/babel-parser.js" }, "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ=="],
 
     "cosmiconfig/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
-
-    "jscpd/fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
-
-    "jscpd-sarif-reporter/fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
     "lint-staged/commander": ["commander@6.2.1", "", {}, "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="],
 
@@ -963,8 +947,6 @@
     "log-update/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
-
-    "node-sarif-builder/fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 

--- a/package.json
+++ b/package.json
@@ -51,12 +51,10 @@
 		"prepublishOnly": "bun run test"
 	},
 	"devDependencies": {
-		"@types/fs-extra": "11.0.4",
 		"@types/node": "25.6.0",
 		"@vitest/coverage-v8": "4.1.8",
 		"enquirer": "2.3.6",
 		"eslint-plugin-security": "4.0.0",
-		"fs-extra": "11.3.5",
 		"fuzzysearch": "1.0.3",
 		"https-proxy-agent": "5.0.0",
 		"husky": "9.1.7",

--- a/src/transports/tar/archive.ts
+++ b/src/transports/tar/archive.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import { constants, cp, mkdtemp, readFile, readdir, rm, access } from 'node:fs/promises';
 import path from 'node:path';
 import * as tar from 'tar';
 import { getProvider, type Repo } from '../../domain/repo.js';
@@ -64,7 +64,7 @@ async function createArchiveSource(dir: string, repo: Repo, hash: string): Promi
 		file: path.join(dir, `${hash}.tar.gz`),
 		subdir: repo.subdir ? `${repo.name}-${hash}${repo.subdir}` : null,
 		url: provider.archiveUrl(repo, hash),
-		workDir: await fs.mkdtemp(path.join(dir, 'extract-')),
+		workDir: await mkdtemp(path.join(dir, 'extract-')),
 	};
 }
 
@@ -73,12 +73,15 @@ async function ensureArchiveFile(context: TarContext, source: ArchiveSource) {
 		return;
 	}
 
-	if (await fs.pathExists(source.file)) {
+	try {
+		await access(source.file, constants.F_OK);
 		context.verboseInfo({
 			code: 'FILE_EXISTS',
 			message: `${source.file} already exists locally`,
 		});
 		return;
+	} catch {
+		// Missing files and permission-denied paths are both treated as absent.
 	}
 
 	mkdirp(path.dirname(source.file));
@@ -128,7 +131,7 @@ async function extractArchive(context: TarContext, source: ArchiveSource, dest: 
 			original: error,
 		});
 	} finally {
-		await fs.remove(source.workDir);
+		await rm(source.workDir, { force: true, recursive: true });
 	}
 }
 
@@ -141,7 +144,7 @@ async function untarWithRetry(context: TarContext, source: ArchiveSource) {
 		}
 
 		try {
-			await fs.remove(source.file);
+			await rm(source.file, { force: true, recursive: true });
 		} catch {
 			// Ignore cleanup failures and continue with a fresh download.
 		}
@@ -187,7 +190,7 @@ function untar(file: string, dest: string, subdir: string | null = null) {
 async function hasGitLfsPointers(dir: string): Promise<boolean> {
 	// Paths are discovered from extracted archive contents under a controlled temp dir.
 	// eslint-disable-next-line security/detect-non-literal-fs-filename
-	const entries = await fs.readdir(dir, { withFileTypes: true });
+	const entries = await readdir(dir, { withFileTypes: true });
 	const checks = entries.map(async (entry) => {
 		const entryPath = path.join(dir, entry.name);
 
@@ -201,7 +204,7 @@ async function hasGitLfsPointers(dir: string): Promise<boolean> {
 
 		// Paths are discovered from extracted archive contents under a controlled temp dir.
 		// eslint-disable-next-line security/detect-non-literal-fs-filename
-		const contents = await fs.readFile(entryPath, 'utf8');
+		const contents = await readFile(entryPath, 'utf8');
 		return (
 			/^version https:\/\/git-lfs\.github\.com\/spec\/v1$/m.test(contents) &&
 			/^oid sha256:[0-9a-f]{64}$/m.test(contents) &&
@@ -215,12 +218,13 @@ async function hasGitLfsPointers(dir: string): Promise<boolean> {
 async function copyExtractedFiles(sourceDir: string, destDir: string) {
 	// Paths are discovered from extracted archive contents under a controlled temp dir.
 	// eslint-disable-next-line security/detect-non-literal-fs-filename
-	const entries = await fs.readdir(sourceDir, { withFileTypes: true });
+	const entries = await readdir(sourceDir, { withFileTypes: true });
 	await Promise.all(
 		entries.map(async (entry) => {
 			const sourcePath = path.join(sourceDir, entry.name);
 			const destinationPath = path.join(destDir, entry.name);
-			await fs.copy(sourcePath, destinationPath);
+			// cp() overwrites existing files the same way the old copy behavior did for this path.
+			await cp(sourcePath, destinationPath, { recursive: true });
 		}),
 	);
 }

--- a/src/transports/tar/cache.ts
+++ b/src/transports/tar/cache.ts
@@ -1,5 +1,5 @@
 import { timingSafeEqual } from 'node:crypto';
-import fs from 'fs-extra';
+import { rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { Repo } from '../../domain/repo.js';
 import { tryRequire } from '../../shared/utils.js';
@@ -35,7 +35,7 @@ export async function updateCache(
 	logs[repo.ref] = new Date().toISOString();
 	// Dynamic cache file paths are derived from repo/ref values within the cache root.
 	// eslint-disable-next-line security/detect-non-literal-fs-filename
-	await fs.writeFile(path.join(dir, 'access.json'), JSON.stringify(logs, null, '  '));
+	await writeFile(path.join(dir, 'access.json'), JSON.stringify(logs, null, '  '));
 
 	const currentHash = cache.get(repo.ref);
 	if (sameHash(currentHash, hash)) {
@@ -44,7 +44,7 @@ export async function updateCache(
 
 	if (currentHash && ![...cache.values()].some((value) => sameHash(value, hash))) {
 		try {
-			await fs.remove(path.join(dir, `${currentHash}.tar.gz`));
+			await rm(path.join(dir, `${currentHash}.tar.gz`), { force: true, recursive: true });
 		} catch {
 			// Ignore cache cleanup failures.
 		}
@@ -53,8 +53,5 @@ export async function updateCache(
 	cache.set(repo.ref, hash);
 	// Dynamic cache file paths are derived from repo/ref values within the cache root.
 	// eslint-disable-next-line security/detect-non-literal-fs-filename
-	await fs.writeFile(
-		path.join(dir, 'map.json'),
-		JSON.stringify(recordFromMap(cache), null, '  '),
-	);
+	await writeFile(path.join(dir, 'map.json'), JSON.stringify(recordFromMap(cache), null, '  '));
 }


### PR DESCRIPTION
## Summary

Removed the direct `fs-extra` dependency from the tar archive/cache path and switched those code paths to Node built-ins.

## Why

This trims a direct dependency that was only used in the tar transport layer, while keeping the existing archive download and cache cleanup behavior intact.

## Changes

- Replaced `fs-extra` calls in `src/transports/tar/archive.ts` with `node:fs/promises` APIs.
- Replaced `fs-extra` calls in `src/transports/tar/cache.ts` with `node:fs/promises` APIs.
- Removed `fs-extra` and `@types/fs-extra` from `package.json`.
- Regenerated `bun.lock` after the manifest change.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes**: none

**Risks / rollout**: `fs.promises.access()` treats missing files and permission-denied paths as absent here to match the previous `fs-extra.pathExists()` behavior.

**Focus areas for reviewers**: archive extraction cleanup, cache file cleanup, and the regenerated lockfile.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes