### PR TITLE
feat: add search_replace directive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ See [package.json](package.json) for the build, dev, and audit scripts. Source o
 
 Tests live in `test/unit/**/*.test.ts` and `test/integration/**/*.test.ts` (see [vitest.config.ts](vitest.config.ts)). Use `bun run test` for the suite excluding `test/integration/private.test.ts`, and `bun run test:integration` for the integration network suite. Prefer updating or adding tests when changing behavior. Use `bun run format:ci` after edits that touch Markdown or JSON.
 Test names should follow the `it('X when Y')` pattern so behavior and trigger are both obvious.
+As a rule of thumb, keep one `describe` block per test file. If a file hits the max-lines rule, prefer a targeted suppression on that `describe` block instead of splitting it up just to satisfy the linter. Split into multiple `describe` blocks only when it actually improves readability.
 The private integration suite in `test/integration/private.test.ts` keeps built-in private SSH fixtures behind `SSH_PRIVATE_KEY`; verification should not assume private repos are available unless that secret is set.
 When verifying production-only bugs in the CLI, reproduce with the published `degit` package (for example `npx degit@latest ...`) instead of running the raw repository source directly.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ emitter.clone('path/to/dest').then(() => {
 
 ## Actions
 
-You can manipulate repositories after they have been cloned with _actions_, specified in a `degit.json` file that lives at the top level of the working directory. Currently, there are two actions — `clone` and `remove`. Additional actions may be added in future.
+You can manipulate repositories after they have been cloned with _actions_, specified in a `degit.json` file that lives at the top level of the working directory. Currently, there are three actions — `clone`, `search_replace`, and `remove`. Additional actions may be added in future.
 
 ### clone
 
@@ -166,6 +166,22 @@ You can manipulate repositories after they have been cloned with _actions_, spec
 ```
 
 This will clone `user/another-repo`, preserving the contents of the existing working directory. This allows you to, say, add a new README.md or starter file to a repo that you do not control. The cloned repo can contain its own `degit.json` actions.
+
+### search_replace
+
+```json
+// degit.json
+[
+	{
+		"action": "search_replace",
+		"files": ["package.json", "README.md"],
+		"pattern": "\\{\\{project_name\\}\\}",
+		"replacement": "PROJECT_NAME"
+	}
+]
+```
+
+This replaces every match of the regular expression in the listed files using the value of the named environment variable. `files` can be a single path or an array of paths, and each path is resolved relative to the destination. Paths outside the destination are skipped.
 
 ### remove
 

--- a/assets/help.md
+++ b/assets/help.md
@@ -58,4 +58,6 @@ Private repositories are handled automatically: degit uses the tarball path by d
 
 `--mode=git` is still accepted for compatibility. `--mode=tar` is the default path and does not need special handling.
 
+Actions can also be defined in a top-level `degit.json` file. Supported actions are `clone`, `search_replace`, and `remove`. `search_replace` only touches explicitly listed files, resolves them relative to the destination, and uses the named environment variable as the replacement value.
+
 See https://github.com/Rich-Harris/degit for more information

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # degit changelog
 
+## 3.5.0
+
+- Add a `search_replace` action for `degit.json` (#364, thanks to @Tythos for the original PR #365).
+
 ## 3.4.7
 
 - Gate clone error details behind `--verbose`.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -175,6 +175,8 @@ A small proof-of-concept docs-sync workflow also runs on PRs that change `src/**
 
 Keep changes focused, squash the branch to a single commit before opening the pull request, add or update tests when behavior changes, and describe the motivation in the pull request so reviewers can follow your intent.
 
+As a rule of thumb, keep one `describe` block per test file. If a file starts hitting the max-lines rule, prefer a targeted suppression on that `describe` block instead of splitting it up just to satisfy the linter. Split into multiple `describe` blocks only when the behaviors are genuinely easier to read that way.
+
 If your pull request resolves an issue, mention it in the PR body with `Fixes #123` or `Closes #123` so GitHub closes the issue automatically when the PR is merged.
 
 Test names should describe behavior in the form `it('X when Y')`, so the action appears first and the triggering condition comes after `when`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.4.7",
+	"version": "3.5.0",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -66,11 +66,18 @@ export type Directive =
 			verbose?: boolean;
 	  }
 	| {
+			action: 'search_replace';
+			files: string | string[];
+			pattern: string;
+			replacement: string;
+	  }
+	| {
 			action: 'remove';
 			files: string | string[];
 	  };
 
 export type CloneDirective = Extract<Directive, { action: 'clone' }>;
+export type SearchReplaceDirective = Extract<Directive, { action: 'search_replace' }>;
 export type RemoveDirective = Extract<Directive, { action: 'remove' }>;
 
 export type Options = ConstructorOptions;

--- a/src/operations/directives.ts
+++ b/src/operations/directives.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import colors from 'yoctocolors';
 import { stashFiles, unstashFiles } from '../shared/utils.js';
 import type { GitClient } from '../domain/types.js';
@@ -8,6 +10,7 @@ import type {
 	EventInfo,
 	FetchFn,
 	RemoveDirective,
+	SearchReplaceDirective,
 } from '../domain/types.js';
 
 type ChildDegit = {
@@ -19,7 +22,9 @@ type DirectiveContext = {
 	fetch: FetchFn;
 	getGitClient(): Promise<GitClient>;
 	hasStashed: boolean;
+	info(info: EventInfo): void;
 	remove(dest: string, action: RemoveDirective): void;
+	warn(info: EventInfo): void;
 };
 
 function attachChildLoggers(child: ChildDegit) {
@@ -78,6 +83,11 @@ async function runDirective(
 		return;
 	}
 
+	if (directive.action === 'search_replace') {
+		searchReplaceFiles(dest, directive, context.info, context.warn);
+		return;
+	}
+
 	context.remove(dest, directive);
 }
 
@@ -98,3 +108,77 @@ export async function applyDirectives(
 		unstashFiles(dir, dest);
 	}
 }
+
+function searchReplaceFiles(
+	dest: string,
+	action: SearchReplaceDirective,
+	info: (info: EventInfo) => void,
+	warn: (info: EventInfo) => void,
+) {
+	/* eslint-disable security/detect-non-literal-regexp, security/detect-non-literal-fs-filename */
+	const files = Array.isArray(action.files) ? action.files : [action.files];
+	const root = path.resolve(dest);
+	const replacement = process.env[action.replacement];
+
+	if (replacement === undefined) {
+		warn({
+			message: `action wants to search_replace using env var ${colors.bold(action.replacement)} but it is not defined, skipping`,
+		});
+		return;
+	}
+
+	const pattern = new RegExp(action.pattern, 'g');
+	const replacedFiles = files.flatMap((file) =>
+		replaceFile(root, file, pattern, replacement, warn),
+	);
+
+	if (replacedFiles.length > 0) {
+		info({
+			message: `replaced content in ${colors.bold(String(replacedFiles.length))} files: ${replacedFiles.map((file) => colors.bold(file)).join(', ')}`,
+		});
+	}
+}
+
+function replaceFile(
+	root: string,
+	file: string,
+	pattern: RegExp,
+	replacement: string,
+	warn: (info: EventInfo) => void,
+) {
+	const filePath = path.resolve(root, file);
+	const relativePath = path.relative(root, filePath);
+
+	if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+		warn({
+			message: `action wants to search_replace ${colors.bold(file)} but it is outside the destination, skipping`,
+		});
+		return [];
+	}
+
+	if (!fs.existsSync(filePath)) {
+		warn({
+			message: `action wants to search_replace ${colors.bold(file)} but it does not exist`,
+		});
+		return [];
+	}
+
+	if (fs.lstatSync(filePath).isDirectory()) {
+		warn({
+			message: `action wants to search_replace ${colors.bold(file)} but it is a directory, skipping`,
+		});
+		return [];
+	}
+
+	const content = fs.readFileSync(filePath, 'utf8');
+	const nextContent = content.replace(pattern, () => replacement);
+
+	if (nextContent === content) {
+		return [];
+	}
+
+	fs.writeFileSync(filePath, nextContent);
+	return [file];
+}
+
+/* eslint-enable security/detect-non-literal-regexp, security/detect-non-literal-fs-filename */

--- a/test/unit/directives.test.ts
+++ b/test/unit/directives.test.ts
@@ -1,0 +1,183 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, it, vi } from 'vitest';
+import { applyDirectives } from '../../src/operations/directives.js';
+
+function makeTempWorkspace(prefix: string) {
+	return fs.mkdtempSync(path.join(process.cwd(), prefix));
+}
+
+function makeDispatcher() {
+	const infos: string[] = [];
+	const warnings: string[] = [];
+	const context = {
+		fetch: vi.fn(),
+		getGitClient: vi.fn(),
+		hasStashed: false,
+		info: vi.fn((info) => infos.push(info.message)),
+		remove: vi.fn(),
+		warn: vi.fn((info) => warnings.push(info.message)),
+	};
+	const createChild = vi.fn(() => ({
+		clone: vi.fn(),
+		on: vi.fn().mockReturnThis(),
+	}));
+
+	return { context, createChild, infos, warnings };
+}
+
+afterEach(() => {
+	delete process.env.PROJECT_NAME;
+});
+
+/* eslint-disable max-lines-per-function */
+describe('search_replace', () => {
+	it('replaces every match in targeted files when the env var exists', async () => {
+		const root = makeTempWorkspace('search-replace-');
+		const dest = path.join(root, 'dest');
+		const { context, createChild, infos, warnings } = makeDispatcher();
+
+		try {
+			fs.mkdirSync(dest, { recursive: true });
+			fs.writeFileSync(
+				path.join(dest, 'README.md'),
+				'hello {{project_name}}\n{{project_name}}!\n',
+			);
+			process.env.PROJECT_NAME = 'degit';
+
+			await applyDirectives(
+				context as never,
+				[
+					{
+						action: 'search_replace',
+						files: 'README.md',
+						pattern: '\\{\\{project_name\\}\\}',
+						replacement: 'PROJECT_NAME',
+					},
+				],
+				root,
+				dest,
+				createChild,
+			);
+
+			assert.equal(
+				fs.readFileSync(path.join(dest, 'README.md'), 'utf8'),
+				'hello degit\ndegit!\n',
+			);
+			assert.equal(infos.length, 1);
+			assert.match(infos[0], /replaced content in .*README\.md/);
+			assert.deepEqual(warnings, []);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	it('warns and skips missing files when the target path does not exist', async () => {
+		const root = makeTempWorkspace('search-replace-');
+		const dest = path.join(root, 'dest');
+		const { context, createChild, warnings } = makeDispatcher();
+
+		try {
+			fs.mkdirSync(dest, { recursive: true });
+			process.env.PROJECT_NAME = 'degit';
+
+			await applyDirectives(
+				context as never,
+				[
+					{
+						action: 'search_replace',
+						files: 'missing.txt',
+						pattern: 'missing',
+						replacement: 'PROJECT_NAME',
+					},
+				],
+				root,
+				dest,
+				createChild,
+			);
+
+			assert.equal(warnings.length, 1);
+			assert.match(warnings[0], /does not exist/);
+			assert.match(warnings[0], /missing\.txt/);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	it('warns and skips paths outside the destination when the target escapes the destination', async () => {
+		const root = makeTempWorkspace('search-replace-');
+		const dest = path.join(root, 'dest');
+		const sibling = path.join(root, 'sibling');
+		const { context, createChild, warnings } = makeDispatcher();
+
+		try {
+			fs.mkdirSync(dest, { recursive: true });
+			fs.mkdirSync(sibling, { recursive: true });
+			fs.writeFileSync(path.join(sibling, 'secret.txt'), 'secret\n');
+			process.env.PROJECT_NAME = 'degit';
+
+			await applyDirectives(
+				context as never,
+				[
+					{
+						action: 'search_replace',
+						files: '../sibling/secret.txt',
+						pattern: 'secret',
+						replacement: 'PROJECT_NAME',
+					},
+				],
+				root,
+				dest,
+				createChild,
+			);
+
+			assert.equal(fs.readFileSync(path.join(sibling, 'secret.txt'), 'utf8'), 'secret\n');
+			assert.equal(warnings.length, 1);
+			assert.match(warnings[0], /outside the destination, skipping/);
+			assert.match(warnings[0], /\.\.\/sibling\/secret\.txt/);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	it('runs search_replace directives through the directive dispatcher when applyDirectives receives search_replace', async () => {
+		const root = makeTempWorkspace('search-replace-');
+		const dest = path.join(root, 'dest');
+		const directivesDir = path.join(root, 'repo');
+		const { context, createChild, infos, warnings } = makeDispatcher();
+
+		try {
+			fs.mkdirSync(dest, { recursive: true });
+			fs.writeFileSync(path.join(dest, 'package.json'), '{"name":"{{project_name}}"}\n');
+			process.env.PROJECT_NAME = 'degit';
+
+			await applyDirectives(
+				context as never,
+				[
+					{
+						action: 'search_replace',
+						files: 'package.json',
+						pattern: '\\{\\{project_name\\}\\}',
+						replacement: 'PROJECT_NAME',
+					},
+				],
+				directivesDir,
+				dest,
+				createChild,
+			);
+
+			assert.equal(
+				fs.readFileSync(path.join(dest, 'package.json'), 'utf8'),
+				'{"name":"degit"}\n',
+			);
+			assert.equal(createChild.mock.calls.length, 0);
+			assert.equal(context.remove.mock.calls.length, 0);
+			assert.equal(infos.length, 1);
+			assert.equal(warnings.length, 0);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+});
+/* eslint-enable max-lines-per-function */


### PR DESCRIPTION
## Summary

**What**

Add a new `search_replace` directive that replaces regex matches in explicitly listed files with the value from a named environment variable.

**Why**

This expands degit's templating support while keeping replacement behavior opt-in, scoped, and easy to reason about.

## Changes

- Added `search_replace` to the directive type model and action dispatcher.
- Implemented destination-relative file replacement with warnings for missing paths and paths that escape the destination.
- Added unit coverage for the happy path, missing files, and escaping paths.
- Consolidated the directive coverage into one `describe` block and documented the test-file style rule in the contributor docs and agent guidance.
- Updated the README, published CLI help text, and changelog entry to reflect the new action.
- Traced the feature back to issue #364 and the original PR #365 by @Tythos.
- Fixes #364.

## Testing

How you verified this:

- [x] Automated tests (`bunx vitest run test/unit/directives.test.ts`)
- [ ] Manual / CLI check if user-facing behavior changed
- [x] CI passes

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

The action is regex-driven and file-scope explicit, so template authors should keep patterns narrow and file lists deliberate.

**Focus areas for reviewers** (optional)

Directive dispatch, path validation, environment-variable substitution, and the updated test/documentation guidance.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
