### PR TITLE
fix: align OXLint configuration and diagnostics

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,8 @@
 {
 	"$schema": "./node_modules/oxlint/configuration_schema.json",
 	"jsPlugins": ["eslint-plugin-security", "./scripts/oxlint-test-guidelines.js"],
+	"plugins": ["import", "node", "promise", "vitest"],
+	"options": { "denyWarnings": true },
 	"rules": {
 		"security/detect-bidi-characters": "error",
 		"security/detect-buffer-noassert": "error",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "lint-staged": "10.5.4",
         "mri": "1.1.6",
         "oxfmt": "0.47.0",
-        "oxlint": "1.62.0",
+        "oxlint": "1.72.0",
         "rimraf": "3.0.2",
         "tar": "^7.5.16",
         "tiny-glob": "0.2.8",
@@ -206,43 +206,43 @@
 
     "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.47.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Sr59Y5ms54ONBjxFeWhVlGyQcHXxcl9DxC23f6yXlRkcos7LXBLoO+KDfxexjHIOZh7cWqrWduzvUjJ+pHp8cQ=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-pKsthNECyvJh8lPTICz6VcwVy2jOqdhhsp1rlxCkhgZR47aKvXPmaRWQDv+zlXpRae4qm1MaaTnutkaOk5aofg=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.72.0", "", { "os": "android", "cpu": "arm" }, "sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.62.0", "", { "os": "android", "cpu": "arm64" }, "sha512-b1AUNViByvgmR2xJDubvLIr+dSuu3uraG7bsAoKo+xrpspPvu6RIn6Fhr2JUhobfep3jwUTy18Huco6GkwdvGQ=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.72.0", "", { "os": "android", "cpu": "arm64" }, "sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.62.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iG+Tvf70UJ6otfwFYIHk36Sjq9cpPP5YLxkoggANNRtzgi3Tj3g8q6Ybqi6AtkU3+yg9QwF7bDCkCS6bbL4PCg=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.72.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EvnajNPDtfknB3ZieeOOyDTwJn9QXDiwfnF4ZDQqART6RG6hjY4WigQcZdGoK2dkB3e1vrmEzN9aYbQCUkh/gQ=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.62.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-oOWI6YPPr5AJUx+yIDlxmuUbQjS5gZX3OH3QisawYvsZgLiQVvZtR0rPBcJTxLWqt2ClrWg0DlSrlUiG5SQNHg=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.72.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.62.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dLP33T7VLCmLVv4cvjkVX+rmkcwNk2UfxmsZPNur/7BQHoQR60zJ7XLiRvNUawlzn0u8ngCa3itjEG73MAMa/w=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.72.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-NroXv2vh+sxVY1uya/rM5pjhx1hm8BzlYpx9q67QP0Xhw5MH2bf5GJylpvLEC+781p1Xli/317EoV9AlGwViag=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-fl//LWNks6qo9chNY60UDYyIwtp7a5cEx4Y/rHPjaarhuwqx6jtbzEpD5V5AqmdL4a6Y5D8zeXg5HF2Cr0QmSQ=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.72.0", "", { "os": "linux", "cpu": "arm" }, "sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-i5vkAuxvueTODV3J2dL61/TXewDHhMFKvtD156cIsk7GsdfiAu7zW7kY0NJXhKeFHeiMZIh7eFNjkPYH6J47HQ=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.72.0", "", { "os": "linux", "cpu": "arm" }, "sha512-4vpXB06h65Ezsy4hRyrGjGrfa1SkVPii09yaajiYhmVpgsFiLD+KNxIx/BNAY+XiO+i1yqp9HHdwqM8VTqa5XQ=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-QwN19LLuIGuOjEflSeJkZmOTfBdBMlTmW8xbMf8TZhjd//cxVNYQPq75q7oKZBJc6hRx3gY7sX0Egc8cEIFZYg=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.72.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-8eCy3FCDuWUM5hWujAv6heMvfZPbcCOU3SdQUAkixZLu5bSzOkNfirJiLGoQFO943xceOKkiQRMQNzH++jM3WA=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.72.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-JGHS9Mnr7iWyyLDxgCv1MhzVpAckgptg00F2gnxt/GD7lQ2SW1BRcxHqhSTaSdDpjWRrBkBxMMh4+Hn3aVtExg=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-NjQ7K7tpTPDe9J+yq8p/s/J0E7lRCkK2uDBDqvT4XIT6f4Z0tlnr59OBg/WcrmVHER1AbrcfyxhGTXgcG8ytWg=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.72.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-oKZed9gmSwze29dEt3/Wnsv6l/Ygw/FUst+8Kfpv2SGeS/glEoTGZAMQw37SVyzFV76UTHJN2snGgxK2t2+8ow=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.72.0", "", { "os": "linux", "cpu": "none" }, "sha512-QMybPS5ij3/vrKG67mqzHwW++91sYxK/PPUVi6SBtNCEzW4niS52fVBdXbQ6nou0wWbUPEpx8Sl/ZjtgE3clXA=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-gBjBxQ+9lGpAYq+ELqw0w8QXsBnkZclFc7GRX2r0LnEVn3ZTEqeIKpKcGjucmp76Q53bvJD0i4qBWBhcfhSfGA=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.72.0", "", { "os": "linux", "cpu": "none" }, "sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.62.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Ew2Kxs9EQ9/mbAIJ2hvocMC0wsOu6YKzStI2eFBDt+Td5O8seVC/oxgRIHqCcl5sf5ratA1nozQBAuv7tphkHg=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.72.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-rpGxph+FjjHcYI5q6uxB3Az+tnfmEnDbSA8+PK9ZE/VzyUAkvBOMeuY7ZQMhu5mpZH7YQDsTdW6Cx4kV/msc6w=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5z25jcAA0gfKyVwz71A0VXgaPlocPoTAxhlv/hgoK6tlCrfoNuw7haWbDHvGMfjXhdic4EqVXGRv5XsTqFnbRQ=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.72.0", "", { "os": "linux", "cpu": "x64" }, "sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-IWpHmMB6ZDllPvqWDkG6AmXrN7JF5e/c4g/0PuURsmlK+vHoYZPB70rr4u1bn3I4LsKCSpqqfveyx6UCOC8wdg=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.72.0", "", { "os": "linux", "cpu": "x64" }, "sha512-SrpbrUL70nG9vh6zP4/oKHWgLuHquwsr7MW9XOn0olBVgh10Uqr8qscKhQoBGEn6olK/IUpn5GSKcdQ5AjUhGA=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.62.0", "", { "os": "none", "cpu": "arm64" }, "sha512-fjlSxxrD5pA594vkyikCS9MnPRjQawW6/BLgyTYkO+73wwPlYjkcZ7LSd974l0Q2zkHQmu4DPvJFLYA7o8xrxQ=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.72.0", "", { "os": "none", "cpu": "arm64" }, "sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.62.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-EiFXr8loNS0Ul3Gu80+9nr1T8jRmnKocqmHHg16tj5ZqTgUXyb97l2rrspVHdDluyFn9JfR4PoJFdNzw4paHww=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.72.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-LWR6ZlFZph+KPjXv8opgZsXRDCdrdQe8VL8Cg9zxCoBS73h6znzZpydVgmdnwj8mB9AuSM5jxEgDJDpQkjboeg=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.62.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-IgOFvL73li1bFgab+hThXYA0N2Xms2kV2MvZN95cebV+fmrZ9AVui1JSxfeeqRLo3CpPxKZlzhyq4G0cnaAvIw=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.72.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.72.0", "", { "os": "win32", "cpu": "x64" }, "sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
@@ -702,7 +702,7 @@
 
     "oxfmt": ["oxfmt@0.47.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.47.0", "@oxfmt/binding-android-arm64": "0.47.0", "@oxfmt/binding-darwin-arm64": "0.47.0", "@oxfmt/binding-darwin-x64": "0.47.0", "@oxfmt/binding-freebsd-x64": "0.47.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.47.0", "@oxfmt/binding-linux-arm-musleabihf": "0.47.0", "@oxfmt/binding-linux-arm64-gnu": "0.47.0", "@oxfmt/binding-linux-arm64-musl": "0.47.0", "@oxfmt/binding-linux-ppc64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-musl": "0.47.0", "@oxfmt/binding-linux-s390x-gnu": "0.47.0", "@oxfmt/binding-linux-x64-gnu": "0.47.0", "@oxfmt/binding-linux-x64-musl": "0.47.0", "@oxfmt/binding-openharmony-arm64": "0.47.0", "@oxfmt/binding-win32-arm64-msvc": "0.47.0", "@oxfmt/binding-win32-ia32-msvc": "0.47.0", "@oxfmt/binding-win32-x64-msvc": "0.47.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA=="],
 
-    "oxlint": ["oxlint@1.62.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.62.0", "@oxlint/binding-android-arm64": "1.62.0", "@oxlint/binding-darwin-arm64": "1.62.0", "@oxlint/binding-darwin-x64": "1.62.0", "@oxlint/binding-freebsd-x64": "1.62.0", "@oxlint/binding-linux-arm-gnueabihf": "1.62.0", "@oxlint/binding-linux-arm-musleabihf": "1.62.0", "@oxlint/binding-linux-arm64-gnu": "1.62.0", "@oxlint/binding-linux-arm64-musl": "1.62.0", "@oxlint/binding-linux-ppc64-gnu": "1.62.0", "@oxlint/binding-linux-riscv64-gnu": "1.62.0", "@oxlint/binding-linux-riscv64-musl": "1.62.0", "@oxlint/binding-linux-s390x-gnu": "1.62.0", "@oxlint/binding-linux-x64-gnu": "1.62.0", "@oxlint/binding-linux-x64-musl": "1.62.0", "@oxlint/binding-openharmony-arm64": "1.62.0", "@oxlint/binding-win32-arm64-msvc": "1.62.0", "@oxlint/binding-win32-ia32-msvc": "1.62.0", "@oxlint/binding-win32-x64-msvc": "1.62.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.18.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-1uFkg6HakjsGIpW9wNdeW4/2LOHW9MEkoWjZUTUfQtIHyLIZPYt00w3Sg+H3lH+206FgBPHBbW5dVE5l2ExECQ=="],
+    "oxlint": ["oxlint@1.72.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.72.0", "@oxlint/binding-android-arm64": "1.72.0", "@oxlint/binding-darwin-arm64": "1.72.0", "@oxlint/binding-darwin-x64": "1.72.0", "@oxlint/binding-freebsd-x64": "1.72.0", "@oxlint/binding-linux-arm-gnueabihf": "1.72.0", "@oxlint/binding-linux-arm-musleabihf": "1.72.0", "@oxlint/binding-linux-arm64-gnu": "1.72.0", "@oxlint/binding-linux-arm64-musl": "1.72.0", "@oxlint/binding-linux-ppc64-gnu": "1.72.0", "@oxlint/binding-linux-riscv64-gnu": "1.72.0", "@oxlint/binding-linux-riscv64-musl": "1.72.0", "@oxlint/binding-linux-s390x-gnu": "1.72.0", "@oxlint/binding-linux-x64-gnu": "1.72.0", "@oxlint/binding-linux-x64-musl": "1.72.0", "@oxlint/binding-openharmony-arm64": "1.72.0", "@oxlint/binding-win32-arm64-msvc": "1.72.0", "@oxlint/binding-win32-ia32-msvc": "1.72.0", "@oxlint/binding-win32-x64-msvc": "1.72.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-1rhdZIP/EvoI91ABIwNU5Q8+bWf8mjrS5UzIOZld4d4bXxJvtlUhlQvaoTogIGin/qdErMOrwaIJvCSIAKTLhA=="],
 
     "p-map": ["p-map@4.0.0", "", { "dependencies": { "aggregate-error": "^3.0.0" } }, "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ=="],
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
-		"lint": "oxlint --import-plugin --fix .",
-		"lint:ci": "oxlint --import-plugin --deny-warnings .",
+		"lint": "oxlint --fix .",
+		"lint:ci": "oxlint .",
 		"typecheck": "tsc --noEmit",
 		"audit": "bun audit",
 		"knip:ci": "knip",
@@ -65,7 +65,7 @@
 		"lint-staged": "10.5.4",
 		"mri": "1.1.6",
 		"oxfmt": "0.47.0",
-		"oxlint": "1.62.0",
+		"oxlint": "1.72.0",
 		"rimraf": "3.0.2",
 		"tar": "^7.5.16",
 		"tiny-glob": "0.2.8",
@@ -80,7 +80,7 @@
 	},
 	"lint-staged": {
 		"*.{js,ts}": [
-			"oxlint --import-plugin --fix --deny-warnings",
+			"oxlint --fix",
 			"git add"
 		],
 		"**/*": [

--- a/scripts/oxlint-test-guidelines.js
+++ b/scripts/oxlint-test-guidelines.js
@@ -23,7 +23,7 @@ function normalizeFilename(context) {
 }
 
 function hasWhen(titleNode, context) {
-	return /\bwhen\b/i.test(context.sourceCode.getText(titleNode));
+	return /\bwhen\b/iu.test(context.sourceCode.getText(titleNode));
 }
 
 const plugin = {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -58,9 +58,9 @@ function parseCliArgs(argv: string[]) {
 function displayHelp() {
 	const help = fs
 		.readFileSync(path.join(dirname, '..', 'assets', 'help.md'), 'utf8')
-		.replaceAll(/^(\s*)#+ (.+)/gm, (_match, indent, title) => indent + colors.bold(title))
-		.replaceAll(/_([^_]+)_/g, (_match, value) => colors.underline(value))
-		.replaceAll(/`([^`]+)`/g, (_match, value) => colors.cyan(value));
+		.replaceAll(/^(\s*)#+ (.+)/gmu, (_match, indent, title) => indent + colors.bold(title))
+		.replaceAll(/_([^_]+)_/gu, (_match, value) => colors.underline(value))
+		.replaceAll(/`([^`]+)`/gu, (_match, value) => colors.cyan(value));
 
 	process.stdout.write(`\n${help}\n`);
 }

--- a/src/domain/repo.ts
+++ b/src/domain/repo.ts
@@ -88,19 +88,19 @@ function resolveSource(source: string, src: string): ResolvedSource {
 
 	if (source.startsWith('https://') || source.startsWith('http://')) {
 		const parsed = new URL(source);
-		site = parsed.hostname.replace(/\.(com|org)$/, '');
-		remainder = parsed.pathname.replace(/^\//, '');
+		site = parsed.hostname.replace(/\.(com|org)$/u, '');
+		remainder = parsed.pathname.replace(/^\//u, '');
 	} else if (source.startsWith('ssh://')) {
 		const parsed = new URL(source);
-		site = parsed.hostname.replace(/\.(com|org)$/, '');
-		remainder = parsed.pathname.replace(/^\//, '');
+		site = parsed.hostname.replace(/\.(com|org)$/u, '');
+		remainder = parsed.pathname.replace(/^\//u, '');
 		transport = 'ssh';
 	} else if (source.startsWith('git@')) {
-		const match = /^git@([^:/]+)[:/](.+)$/.exec(source);
+		const match = /^git@([^:/]+)[:/](.+)$/u.exec(source);
 		if (!match) {
 			throw new DegitError(`could not parse ${src}`, { code: 'BAD_SRC' });
 		}
-		site = match[1].replace(/\.(com|org)$/, '');
+		site = match[1].replace(/\.(com|org)$/u, '');
 		remainder = match[2];
 		transport = 'ssh';
 	} else if (source.startsWith('git.sr.ht/')) {
@@ -144,7 +144,7 @@ export function parse(src: string): Repo {
 		});
 	}
 
-	const name = rawName.replace(/\.git$/, '');
+	const name = rawName.replace(/\.git$/u, '');
 	const subdir = subdirParts.length > 0 ? `/${subdirParts.join('/')}` : undefined;
 
 	const domain = customDomain ?? provider.domain;

--- a/src/operations/directives.ts
+++ b/src/operations/directives.ts
@@ -127,7 +127,7 @@ function searchReplaceFiles(
 		return;
 	}
 
-	const pattern = new RegExp(action.pattern, 'g');
+	const pattern = new RegExp(action.pattern, 'gu');
 	const replacedFiles = files.flatMap((file) =>
 		replaceFile(root, file, pattern, replacement, warn),
 	);

--- a/src/transports/git/client-utils.ts
+++ b/src/transports/git/client-utils.ts
@@ -14,7 +14,7 @@ export function getGitUrl(repo: Repo, transport: Repo['transport'] = repo.transp
 }
 
 export function isCommitHash(ref: string) {
-	return /^[0-9a-f]{7,40}$/i.test(ref);
+	return /^[0-9a-f]{7,40}$/iu.test(ref);
 }
 
 export function normalizeGitRef(ref: string) {
@@ -83,7 +83,7 @@ function mapRemoteRef(refName: string, refHash: string): Ref {
 		};
 	}
 
-	const match = /refs\/([^/]+)\/(.+)/.exec(refName);
+	const match = /refs\/([^/]+)\/(.+)/u.exec(refName);
 	if (!match) {
 		throw new DegitError(`could not parse ${refName}`, {
 			code: 'BAD_REF',
@@ -130,13 +130,13 @@ export function parseGitLsRemoteOutput(output: string): Ref[] {
 	const refs = new Map<string, Ref>();
 	const symrefs = new Map<string, string>();
 
-	for (const rawLine of output.split(/\r?\n/)) {
+	for (const rawLine of output.split(/\r?\n/u)) {
 		const line = rawLine.trim();
 		if (!line) {
 			continue;
 		}
 
-		const symrefMatch = /^ref:\s+(.+)\t(.+)$/.exec(line);
+		const symrefMatch = /^ref:\s+(.+)\t(.+)$/u.exec(line);
 		if (symrefMatch) {
 			symrefs.set(symrefMatch[2], symrefMatch[1]);
 			continue;

--- a/src/transports/tar/archive.ts
+++ b/src/transports/tar/archive.ts
@@ -206,9 +206,9 @@ async function hasGitLfsPointers(dir: string): Promise<boolean> {
 		// eslint-disable-next-line security/detect-non-literal-fs-filename
 		const contents = await readFile(entryPath, 'utf8');
 		return (
-			/^version https:\/\/git-lfs\.github\.com\/spec\/v1$/m.test(contents) &&
-			/^oid sha256:[0-9a-f]{64}$/m.test(contents) &&
-			/^size \d+$/m.test(contents)
+			/^version https:\/\/git-lfs\.github\.com\/spec\/v1$/mu.test(contents) &&
+			/^oid sha256:[0-9a-f]{64}$/mu.test(contents) &&
+			/^size \d+$/mu.test(contents)
 		);
 	});
 

--- a/test/integration/private.test.ts
+++ b/test/integration/private.test.ts
@@ -34,11 +34,8 @@ describe('private integration suite', () => {
 	for (const test of privateIntegrationRepos) {
 		it(`clones the pinned ${test.site} repository when the integration suite runs`, async () => {
 			const integrationTmp = path.join('.tmp', 'integration-suite-private', test.site);
+			assert.ok(test.src, `integration repo ${test.site} is missing a source`);
 			const source = test.src;
-
-			if (!source) {
-				throw new Error(`integration repo ${test.site} is missing a source`);
-			}
 
 			await rimraf(integrationTmp);
 

--- a/test/integration/public.test.ts
+++ b/test/integration/public.test.ts
@@ -40,11 +40,8 @@ describe('public integration suite', () => {
 	for (const test of publicRepos) {
 		it(`clones the pinned ${test.site} repository when the integration suite runs`, async () => {
 			const integrationTmp = path.join('.tmp', 'integration-suite-public', test.site);
-			const source = test.src ?? test.gitUrl;
-
-			if (!source) {
-				throw new Error(`integration repo ${test.site} is missing a source`);
-			}
+			const source = [test.src, test.gitUrl].find(Boolean);
+			assert.ok(source, `integration repo ${test.site} is missing a source`);
 
 			await rimraf(integrationTmp);
 

--- a/test/unit/bin.test.ts
+++ b/test/unit/bin.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { sync as rimraf } from 'rimraf';
 
 vi.mock('../../src/index.js', () => ({
-	default: vi.fn(),
+	default: vi.fn<(...args: any[]) => any>(),
 }));
 
 vi.mock('../../src/shared/utils.js', async () => {
@@ -20,7 +20,7 @@ vi.mock('../../src/shared/utils.js', async () => {
 });
 
 vi.mock('tiny-glob/sync.js', () => ({
-	default: vi.fn((pattern: string) => {
+	default: vi.fn<(pattern: string) => string[]>((pattern: string) => {
 		if (pattern === '**/access.json') {
 			return ['github/user-a/repo-a/access.json', 'github/user-b/repo-b/access.json'];
 		}
@@ -35,7 +35,7 @@ vi.mock('tiny-glob/sync.js', () => ({
 
 vi.mock('enquirer', () => ({
 	default: {
-		prompt: vi.fn(),
+		prompt: vi.fn<(...args: any[]) => Promise<any>>(),
 	},
 }));
 
@@ -66,11 +66,11 @@ describe('degit bin', () => {
 	function mockEventClone(eventName, message) {
 		const handlers = {};
 		mockDegit.mockReturnValue({
-			clone: vi.fn().mockImplementation(() => {
+			clone: vi.fn<() => Promise<void>>().mockImplementation(() => {
 				handlers[eventName]({ message });
 				return Promise.resolve();
 			}),
-			on: vi.fn(function on(ev, fn) {
+			on: vi.fn<(ev: string, fn: (...args: any[]) => any) => any>(function on(ev, fn) {
 				handlers[ev] = fn;
 				return this;
 			}),
@@ -87,8 +87,8 @@ describe('degit bin', () => {
 		) => void,
 	) {
 		mockDegit.mockReturnValue({
-			clone: vi.fn().mockReturnValue(Promise.reject(error)),
-			on: vi.fn().mockReturnThis(),
+			clone: vi.fn<() => Promise<never>>().mockReturnValue(Promise.reject(error)),
+			on: vi.fn<(...args: any[]) => any>().mockReturnThis(),
 		} as never);
 
 		const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
@@ -118,8 +118,8 @@ describe('degit bin', () => {
 		clearInteractiveFixtures();
 		vi.clearAllMocks();
 		mockDegit.mockReturnValue({
-			clone: vi.fn(() => Promise.resolve()),
-			on: vi.fn().mockReturnThis(),
+			clone: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+			on: vi.fn<(...args: any[]) => any>().mockReturnThis(),
 		} as never);
 	});
 
@@ -136,7 +136,7 @@ describe('degit bin', () => {
 			},
 			encoding: 'utf8',
 		});
-		const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+		const output = [result.stdout, result.stderr].join('');
 		assert.ok(output.length > 0);
 		assert.ok(output.includes('degit'));
 	});
@@ -146,9 +146,7 @@ describe('degit bin', () => {
 		const orig = process.stdout.write.bind(process.stdout);
 		process.stdout.write = ((chunk, enc, cb) => {
 			chunks.push(String(chunk));
-			if (typeof cb === 'function') {
-				cb();
-			}
+			cb?.();
 			return true;
 		}) as typeof process.stdout.write;
 		try {
@@ -191,19 +189,16 @@ describe('degit bin', () => {
 			const srcQuestion = (
 				questions as Array<{ name?: string; choices?: Array<{ value: string }> }>
 			).find((question) => question.name === 'src');
-			if (srcQuestion) {
-				assert.deepEqual(
-					srcQuestion.choices.map((choice) => choice.value),
-					['github:user-b/repo-b#main', 'github:user-a/repo-a#main'],
-				);
-				return Promise.resolve({
-					cache: false,
-					dest: '.tmp/bin-suite/from-interactive',
-					src: 'github:user-b/repo-b#main',
-				});
-			}
-
-			return Promise.resolve({});
+			assert.ok(srcQuestion);
+			assert.deepEqual(
+				srcQuestion.choices.map((choice) => choice.value),
+				['github:user-b/repo-b#main', 'github:user-a/repo-a#main'],
+			);
+			return Promise.resolve({
+				cache: false,
+				dest: '.tmp/bin-suite/from-interactive',
+				src: 'github:user-b/repo-b#main',
+			});
 		});
 
 		await main(['node', 'bin']);
@@ -220,8 +215,8 @@ describe('degit bin', () => {
 
 	it('forwards explicit git mode when argv passes --mode=git', async () => {
 		mockDegit.mockReturnValue({
-			clone: vi.fn(() => Promise.resolve()),
-			on: vi.fn().mockReturnThis(),
+			clone: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+			on: vi.fn<(...args: any[]) => any>().mockReturnThis(),
 		} as never);
 		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		try {
@@ -274,6 +269,7 @@ describe('degit bin', () => {
 			await waitForCondition(() =>
 				outSpy.mock.calls.some((c) => String(c[0]).includes('--verbose')),
 			);
+			expect(outSpy).toHaveBeenCalled();
 		} finally {
 			outSpy.mockRestore();
 		}
@@ -287,6 +283,7 @@ describe('degit bin', () => {
 			await waitForCondition(() =>
 				warnSpy.mock.calls.some((c) => String(c[0]).includes('--force')),
 			);
+			expect(warnSpy).toHaveBeenCalled();
 		} finally {
 			warnSpy.mockRestore();
 		}

--- a/test/unit/directives.test.ts
+++ b/test/unit/directives.test.ts
@@ -12,16 +12,16 @@ function makeDispatcher() {
 	const infos: string[] = [];
 	const warnings: string[] = [];
 	const context = {
-		fetch: vi.fn(),
-		getGitClient: vi.fn(),
+		fetch: vi.fn<(...args: any[]) => any>(),
+		getGitClient: vi.fn<(...args: any[]) => any>(),
 		hasStashed: false,
-		info: vi.fn((info) => infos.push(info.message)),
-		remove: vi.fn(),
-		warn: vi.fn((info) => warnings.push(info.message)),
+		info: vi.fn<(...args: any[]) => any>((info) => infos.push(info.message)),
+		remove: vi.fn<(...args: any[]) => any>(),
+		warn: vi.fn<(...args: any[]) => any>((info) => warnings.push(info.message)),
 	};
-	const createChild = vi.fn(() => ({
-		clone: vi.fn(),
-		on: vi.fn().mockReturnThis(),
+	const createChild = vi.fn<(...args: any[]) => any>(() => ({
+		clone: vi.fn<(...args: any[]) => any>(),
+		on: vi.fn<(...args: any[]) => any>().mockReturnThis(),
 	}));
 
 	return { context, createChild, infos, warnings };
@@ -66,7 +66,7 @@ describe('search_replace', () => {
 				'hello degit\ndegit!\n',
 			);
 			assert.equal(infos.length, 1);
-			assert.match(infos[0], /replaced content in .*README\.md/);
+			assert.match(infos[0], /replaced content in .*README\.md/u);
 			assert.deepEqual(warnings, []);
 		} finally {
 			fs.rmSync(root, { force: true, recursive: true });
@@ -98,8 +98,8 @@ describe('search_replace', () => {
 			);
 
 			assert.equal(warnings.length, 1);
-			assert.match(warnings[0], /does not exist/);
-			assert.match(warnings[0], /missing\.txt/);
+			assert.match(warnings[0], /does not exist/u);
+			assert.match(warnings[0], /missing\.txt/u);
 		} finally {
 			fs.rmSync(root, { force: true, recursive: true });
 		}
@@ -134,8 +134,8 @@ describe('search_replace', () => {
 
 			assert.equal(fs.readFileSync(path.join(sibling, 'secret.txt'), 'utf8'), 'secret\n');
 			assert.equal(warnings.length, 1);
-			assert.match(warnings[0], /outside the destination, skipping/);
-			assert.match(warnings[0], /\.\.\/sibling\/secret\.txt/);
+			assert.match(warnings[0], /outside the destination, skipping/u);
+			assert.match(warnings[0], /\.\.\/sibling\/secret\.txt/u);
 		} finally {
 			fs.rmSync(root, { force: true, recursive: true });
 		}

--- a/test/unit/git-client.test.ts
+++ b/test/unit/git-client.test.ts
@@ -3,23 +3,23 @@ import { PassThrough } from 'node:stream';
 import { vi } from 'vitest';
 
 const { cloneMock, checkoutMock, getRemoteInfo2Mock, listServerRefsMock } = vi.hoisted(() => ({
-	cloneMock: vi.fn(),
-	checkoutMock: vi.fn(),
-	getRemoteInfo2Mock: vi.fn(),
-	listServerRefsMock: vi.fn(),
+	cloneMock: vi.fn<(...args: any[]) => any>(),
+	checkoutMock: vi.fn<(...args: any[]) => any>(),
+	getRemoteInfo2Mock: vi.fn<(...args: any[]) => any>(),
+	listServerRefsMock: vi.fn<(...args: any[]) => any>(),
 }));
 
-const spawnMock = vi.hoisted(() => vi.fn());
-const execFileMock = vi.fn(
-	(command: string, _args: string[], callback: (error?: unknown) => void) => {
-		callback(
-			Object.assign(new Error(`spawn ${command} ENOENT`), {
-				code: 'ENOENT',
-				syscall: `spawn ${command}`,
-			}),
-		);
-	},
-);
+const spawnMock = vi.hoisted(() => vi.fn<(...args: any[]) => any>());
+const execFileMock = vi.fn<
+	(command: string, args: string[], callback: (error?: unknown) => void) => void
+>((command: string, _args: string[], callback: (error?: unknown) => void) => {
+	callback(
+		Object.assign(new Error(`spawn ${command} ENOENT`), {
+			code: 'ENOENT',
+			syscall: `spawn ${command}`,
+		}),
+	);
+});
 
 type SpawnProcess = {
 	stdout: PassThrough;
@@ -241,11 +241,11 @@ describe('git client', () => {
 	});
 
 	it('reports a missing git binary when fetching refs over ssh', async () => {
-		await assert.rejects(
-			createGitClient().fetchRefs(sshRepo),
-			(error: any) =>
-				error.code === 'GIT_NOT_FOUND' && /git is not installed/.test(error.message),
-		);
+		await assert.rejects(createGitClient().fetchRefs(sshRepo), (error: any) => {
+			assert.equal(error.code, 'GIT_NOT_FOUND');
+			assert.match(error.message, /git is not installed/u);
+			return true;
+		});
 	});
 
 	it('reports a missing git binary when cloning over ssh', async () => {
@@ -262,8 +262,11 @@ describe('git client', () => {
 
 		await assert.rejects(
 			createGitClient().clone(sshRepo, '.tmp/git-client-test'),
-			(error: any) =>
-				error.code === 'GIT_NOT_FOUND' && /git is not installed/.test(error.message),
+			(error: any) => {
+				assert.equal(error.code, 'GIT_NOT_FOUND');
+				assert.match(error.message, /git is not installed/u);
+				return true;
+			},
 		);
 	});
 

--- a/test/unit/index-git-suites.test.ts
+++ b/test/unit/index-git-suites.test.ts
@@ -106,6 +106,7 @@ describe('degit index git suites', () => {
 			const dest = `${suiteTmp}/test-repo`;
 			clearArchiveCache(suiteCache, test);
 			const archiveFile = await createArchiveFixture(`degit-test-repo-${refsHash}`, suiteTmp);
+			expect(fs.existsSync(archiveFile)).toBe(true);
 			await cloneAndExpectTarContent(
 				test,
 				archiveFile,
@@ -124,6 +125,7 @@ describe('degit index git suites', () => {
 				`degit-test-repo-${refsHash}`,
 				suiteTmp,
 			);
+			expect(fs.existsSync(archiveFile)).toBe(true);
 			await cloneAndExpectGitFallback(test, archiveFile, dest);
 		});
 	});

--- a/test/unit/index-tar-suites.test.ts
+++ b/test/unit/index-tar-suites.test.ts
@@ -136,7 +136,7 @@ describe('degit index tar suites', () => {
 
 		await assert.rejects(
 			async () => await degit(test.publicSrc, { git: gitMock.fn }).clone(dest),
-			(err: any) => err && err.code === 'MISSING_REF',
+			(err: any) => err?.code === 'MISSING_REF',
 		);
 	});
 

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -84,7 +84,7 @@ describe('degit index', () => {
 	it('throws BAD_SRC when gitlab:// has no user or repo after host', () => {
 		assert.throws(
 			() => parse('gitlab://myhost.com'),
-			(err: any) => err && err.code === 'BAD_SRC',
+			(err: any) => err?.code === 'BAD_SRC',
 		);
 	});
 
@@ -100,7 +100,7 @@ describe('degit index', () => {
 			() => {
 				degit('codeberg:Rich-Harris/degit-test-repo');
 			},
-			(err: any) => err && err.code === 'UNSUPPORTED_HOST',
+			(err: any) => err?.code === 'UNSUPPORTED_HOST',
 		);
 	});
 
@@ -109,14 +109,14 @@ describe('degit index', () => {
 		fs.writeFileSync(path.join(suiteTmp, 'ne/x'), '1');
 		await assert.rejects(
 			async () => await degit('Rich-Harris/degit-test-repo').clone(path.join(suiteTmp, 'ne')),
-			(err: any) => err && err.code === 'DEST_NOT_EMPTY',
+			(err: any) => err?.code === 'DEST_NOT_EMPTY',
 		);
 	});
 
 	it('throws when mode is not a supported value', () => {
 		assert.throws(
 			() => degit('Rich-Harris/degit-test-repo', { mode: 'svn' as never }),
-			/Valid modes are/,
+			/Valid modes are/u,
 		);
 	});
 
@@ -156,8 +156,11 @@ describe('degit index', () => {
 
 			assert.equal(fs.existsSync(path.join(sibling, 'secret.txt')), true);
 			assert.equal(warnings.length, 1);
-			assert.match(warnings[0], /action wants to remove .*outside the destination, skipping/);
-			assert.match(warnings[0], /\.\.\/sibling/);
+			assert.match(
+				warnings[0],
+				/action wants to remove .*outside the destination, skipping/u,
+			);
+			assert.match(warnings[0], /\.\.\/sibling/u);
 		} finally {
 			fs.rmSync(workspace, { force: true, recursive: true });
 		}

--- a/test/unit/lazy-git.test.ts
+++ b/test/unit/lazy-git.test.ts
@@ -5,10 +5,10 @@ import assert from 'node:assert';
 import { vi } from 'vitest';
 
 let gitClientLoaded = false;
-const fetchRefs = vi.fn(() => [
+const fetchRefs = vi.fn<() => { hash: string; type: string }[]>(() => [
 	{ hash: '0123456789abcdef0123456789abcdef0123456789', type: 'HEAD' },
 ]);
-const clone = vi.fn(async () => {});
+const clone = vi.fn<() => Promise<void>>(async () => {});
 
 vi.mock('../../src/transports/git/client.js', () => {
 	gitClientLoaded = true;

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -91,9 +91,7 @@ describe('shared utils', () => {
 	it('resumes redirect responses when following a redirected archive fetch', async () => {
 		const createWriteStreamSpy = vi.spyOn(fs, 'createWriteStream').mockReturnValue({
 			on(event: string, handler: () => void) {
-				if (event === 'finish') {
-					queueMicrotask(handler);
-				}
+				queueMicrotask(handler);
 
 				return this;
 			},
@@ -101,27 +99,34 @@ describe('shared utils', () => {
 
 		const response1 = {
 			headers: { location: 'https://example.com/archive.tar.gz' },
-			pipe: vi.fn(),
-			resume: vi.fn(),
+			pipe: vi.fn<(...args: any[]) => any>(),
+			resume: vi.fn<(...args: any[]) => any>(),
 			statusCode: 302,
 			statusMessage: 'Found',
 		};
 		const response2 = {
 			headers: {},
-			pipe: vi.fn((stream) => stream),
-			resume: vi.fn(),
+			pipe: vi.fn<(...args: any[]) => any>((stream) => stream),
+			resume: vi.fn<(...args: any[]) => any>(),
 			statusCode: 200,
 			statusMessage: 'OK',
 		};
 
-		const getSpy = vi.spyOn(https, 'get').mockImplementation(((options, callback) => {
-			callback((getSpy.mock.calls.length === 1 ? response1 : response2) as never);
-			return {
-				on() {
-					return this;
-				},
-			};
-		}) as never);
+		const request = () => ({
+			on() {
+				return this;
+			},
+		});
+		const getSpy = vi
+			.spyOn(https, 'get')
+			.mockImplementationOnce(((options, callback) => {
+				callback(response1 as never);
+				return request();
+			}) as never)
+			.mockImplementation(((options, callback) => {
+				callback(response2 as never);
+				return request();
+			}) as never);
 
 		try {
 			await fetch('https://example.com/archive.tar.gz', '/tmp/degit-fetch-test.tar.gz');


### PR DESCRIPTION
## Summary

**What**

Align the OXLint configuration and codebase with the enabled Vitest and Unicode-regexp rules.

**Why**

Keep lint enforcement centralized and allow the full project to pass OXLint without suppressing warnings.

## Changes

- Enable the `import`, `node`, `promise`, and `vitest` OXLint plugins, with warnings treated as errors in `.oxlintrc.json`.
- Upgrade OXLint from 1.62.0 to 1.72.0 and simplify lint scripts to use the shared configuration.
- Update test assertions and mock typing to comply with the enabled Vitest lint rules.
- Add Unicode flags to regexes in source, tests, and the custom OXLint plugin.

## Testing

How you verified this (commands, scenarios, or N/A):

- `bun run lint:ci`
- `bun run typecheck`
- `bun run format:ci`
- `bun run test`

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes**

None.

**Risks / rollout**

Low risk. The only behavior-affecting runtime change is Unicode mode for existing regular expressions; the directive replacement path remains covered by its unit tests.

**Focus areas for reviewers** (optional)

Review the OXLint plugin set and the `u` flag added to the dynamic search-and-replace regular expression.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [ ] Squashed to a single commit
- [x] No unrelated drive-by changes
