### PR TITLE
chore(release): 3.6.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 3.6.2
+
+- Fix Bitbucket subdirectory clones that silently create an empty directory.
+
 ## 3.6.1
 
 - Load `degit.json` as JSON instead of an executable module.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 3.6.2
 
-- Fix Bitbucket subdirectory clones that silently create an empty directory.
+- Fix Bitbucket subdirectory clones that silently create an empty directory ([#371](https://github.com/Rich-Harris/degit/issues/371)).
 
 ## 3.6.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",


### PR DESCRIPTION
## Summary

**What**

Prepare the `3.6.2` patch release.

**Why**

Publish the Bitbucket subdirectory-cloning fix from #461 as a patch release.

## Changes

- Bump the package version from `3.6.1` to `3.6.2`.
- Add the Bitbucket subdirectory fix to the changelog.

## Testing

How you verified this (commands, scenarios, or N/A):

- `bun run --cwd /Users/yboaronben/dev/oss/degit format:ci`
- `bun run --cwd /Users/yboaronben/dev/oss/degit test` (98 tests, including the Bitbucket subdirectory integration test)

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes** None.

**Risks / rollout** None; this only prepares the patch-release metadata for an already-merged fix.

**Focus areas for reviewers** Confirm the version and changelog entry match the intended patch release.

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
