### PR TITLE
feat: parse branch and subdirectory from full provider URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ To clone a specific subdirectory instead of the entire repo, just add it to the 
 degit user/repo/subdirectory
 ```
 
+You can also paste a full GitHub URL to a subdirectory:
+
+```bash
+degit https://github.com/user/repo/tree/main/subdirectory
+```
+
 ### HTTPS proxying
 
 If you have an `https_proxy` environment variable, Degit will use it.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # degit changelog
 
-## Unreleased
+## 3.6.3
+
+- Accept full subdirectory URLs containing branch path segments such as `/tree/main/...` ([#370](https://github.com/Rich-Harris/degit/issues/370)).
 
 ## 3.6.2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.6.2",
+	"version": "3.6.3",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",

--- a/src/domain/repo.ts
+++ b/src/domain/repo.ts
@@ -65,6 +65,7 @@ type ResolvedSource = {
 	site: string;
 	transport: 'https' | 'ssh';
 	customDomain?: string;
+	isWebUrl: boolean;
 };
 
 function parseGitlabUrl(source: string, src: string): ResolvedSource {
@@ -78,23 +79,27 @@ function parseGitlabUrl(source: string, src: string): ResolvedSource {
 		remainder: path.slice(slashIndex + 1),
 		site: 'gitlab',
 		transport: 'https',
+		isWebUrl: true,
 	};
 }
 
 function resolveSource(source: string, src: string): ResolvedSource {
 	let site = 'github';
 	let transport: 'https' | 'ssh' = 'https';
+	let isWebUrl = false;
 	let remainder = source;
 
 	if (source.startsWith('https://') || source.startsWith('http://')) {
 		const parsed = new URL(source);
 		site = parsed.hostname.replace(/\.(com|org)$/u, '');
 		remainder = parsed.pathname.replace(/^\//u, '');
+		isWebUrl = true;
 	} else if (source.startsWith('ssh://')) {
 		const parsed = new URL(source);
 		site = parsed.hostname.replace(/\.(com|org)$/u, '');
 		remainder = parsed.pathname.replace(/^\//u, '');
 		transport = 'ssh';
+		isWebUrl = true;
 	} else if (source.startsWith('git@')) {
 		const match = /^git@([^:/]+)[:/](.+)$/u.exec(source);
 		if (!match) {
@@ -117,12 +122,47 @@ function resolveSource(source: string, src: string): ResolvedSource {
 		}
 	}
 
-	return { remainder, site, transport };
+	return { remainder, site, transport, isWebUrl };
+}
+
+function parseWebPath(
+	site: GitProvider,
+	segments: string[],
+): { ref: string; subdir: string[] } | undefined {
+	switch (site) {
+		case 'github': {
+			const i = segments.findIndex(
+				(s, idx) => (s === 'tree' || s === 'blob') && idx + 1 < segments.length,
+			);
+			if (i === -1) return undefined;
+			return { ref: segments[i + 1], subdir: segments.slice(i + 2) };
+		}
+		case 'gitlab': {
+			const i = segments.findIndex(
+				(s, idx) =>
+					s === '-' &&
+					(segments[idx + 1] === 'tree' || segments[idx + 1] === 'blob') &&
+					idx + 2 < segments.length,
+			);
+			if (i === -1) return undefined;
+			return { ref: segments[i + 2], subdir: segments.slice(i + 3) };
+		}
+		case 'bitbucket': {
+			const i = segments.findIndex((s, idx) => s === 'src' && idx + 1 < segments.length);
+			if (i === -1) return undefined;
+			return { ref: segments[i + 1], subdir: segments.slice(i + 2) };
+		}
+		case 'git.sr.ht': {
+			const i = segments.findIndex((s, idx) => s === 'tree' && idx + 1 < segments.length);
+			if (i === -1) return undefined;
+			return { ref: segments[i + 1], subdir: segments.slice(i + 2) };
+		}
+	}
 }
 
 export function parse(src: string): Repo {
 	const [source, refValue = 'HEAD'] = src.split('#', 2);
-	const { remainder, site, transport, customDomain } = resolveSource(source, src);
+	const { remainder, site, transport, customDomain, isWebUrl } = resolveSource(source, src);
 
 	if (!supported.has(site)) {
 		throw new DegitError(`degit supports GitHub, GitLab, Sourcehut and BitBucket`, {
@@ -137,7 +177,7 @@ export function parse(src: string): Repo {
 		});
 	}
 
-	const [user, rawName, ...subdirParts] = remainder.split('/').filter(Boolean);
+	const [user, rawName, ...rest] = remainder.split('/').filter(Boolean);
 	if (!user || !rawName) {
 		throw new DegitError(`could not parse ${src}`, {
 			code: 'BAD_SRC',
@@ -145,11 +185,24 @@ export function parse(src: string): Repo {
 	}
 
 	const name = rawName.replace(/\.git$/u, '');
+
+	let ref = refValue;
+	let subdirParts = rest;
+	if (isWebUrl) {
+		const parsed = parseWebPath(site as GitProvider, rest);
+		if (parsed) {
+			if (refValue === 'HEAD') {
+				ref = parsed.ref;
+			}
+			subdirParts = parsed.subdir;
+		}
+	}
+
 	const subdir = subdirParts.length > 0 ? `/${subdirParts.join('/')}` : undefined;
 
 	const domain = customDomain ?? provider.domain;
 	const url = `https://${domain}/${user}/${name}`;
 	const ssh = `ssh://git@${domain}/${user}/${name}`;
 
-	return { mode: 'tar', name, ref: refValue, site, ssh, subdir, transport, url, user };
+	return { mode: 'tar', name, ref, site, ssh, subdir, transport, url, user };
 }

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -75,6 +75,52 @@ describe('degit index', () => {
 		assert.equal(repo.url, 'https://gitlab.com/user.name/repo');
 	});
 
+	it('parses a full GitHub tree URL into a ref and subdirectory when the URL contains a branch path', () => {
+		const repo = parse('https://github.com/TanStack/table/tree/main/examples/react/filters');
+
+		assert.equal(repo.user, 'TanStack');
+		assert.equal(repo.name, 'table');
+		assert.equal(repo.ref, 'main');
+		assert.equal(repo.subdir, '/examples/react/filters');
+		assert.equal(repo.url, 'https://github.com/TanStack/table');
+		assert.equal(repo.ssh, 'ssh://git@github.com/TanStack/table');
+	});
+
+	it('parses a full GitHub tree URL into only a ref when no subdirectory is given', () => {
+		const repo = parse('https://github.com/user/repo/tree/main');
+
+		assert.equal(repo.ref, 'main');
+		assert.equal(repo.subdir, undefined);
+	});
+
+	it('uses an explicit #ref over the branch in a full URL when both are provided', () => {
+		const repo = parse('https://github.com/user/repo/tree/main/subdir#dev');
+
+		assert.equal(repo.ref, 'dev');
+		assert.equal(repo.subdir, '/subdir');
+	});
+
+	it('parses a full GitLab tree URL into a ref and subdirectory when the URL uses the GitLab marker', () => {
+		const repo = parse('https://gitlab.com/user/repo/-/tree/dev/sub/dir');
+
+		assert.equal(repo.ref, 'dev');
+		assert.equal(repo.subdir, '/sub/dir');
+	});
+
+	it('parses a full Bitbucket src URL into a ref and subdirectory when the URL uses the src marker', () => {
+		const repo = parse('https://bitbucket.org/user/repo/src/main/sub');
+
+		assert.equal(repo.ref, 'main');
+		assert.equal(repo.subdir, '/sub');
+	});
+
+	it('treats shorthand paths literally when they contain tree-like segments', () => {
+		const repo = parse('github:user/repo/tree');
+
+		assert.equal(repo.ref, 'HEAD');
+		assert.equal(repo.subdir, '/tree');
+	});
+
 	it('parses gitlab: prefix to gitlab.com when dot is in repo name', () => {
 		const repo = parse('gitlab:user/my.repo');
 


### PR DESCRIPTION
## Summary

**What**

Allow URLs like `https://github.com/owner/repo/tree/main/subdir` to work without manually removing the `/tree/<branch>` segment.

**Why**

Fixes #370 — users naturally copy GitHub subdirectory URLs from the browser, which include the branch marker, and `degit` currently treats `/tree/main/...` as a literal subdirectory path.

## Changes

- `src/domain/repo.ts` now recognizes provider-specific branch markers (`tree`/`blob` for GitHub, `/-/tree` for GitLab, `src` for Bitbucket, `tree` for Sourcehut) and extracts the ref and subdirectory accordingly.
- An explicit `#ref` still takes precedence over the branch in the URL path.
- Added unit tests for GitHub, GitLab, and Bitbucket full-URL cases, plus a guard to keep shorthand paths literal.
- Updated `README.md` and `CHANGELOG.md`.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [x] Manual / CLI check if user-facing behavior changed (`npx degit@latest` reproduction + fixed build verification)
- [x] CI passes

## Review notes

**Breaking changes**

None.

**Risks / rollout**

None expected; only URL parsing changed, and shorthand sources remain literal.

**Focus areas for reviewers**

The marker detection is gated to web/SSH-style URLs (`isWebUrl`) so shorthand paths like `github:user/repo/tree` are not reinterpreted.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes

Closes #370

Generated with [Devin](https://devin.ai)