### PR TITLE
feat: add no-more-docs oxlint rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,10 @@
 {
 	"$schema": "./node_modules/oxlint/configuration_schema.json",
-	"jsPlugins": ["eslint-plugin-security", "./scripts/oxlint-test-guidelines.js"],
+	"jsPlugins": [
+		"eslint-plugin-security",
+		"./scripts/oxlint-test-guidelines.js",
+		"./scripts/oxlint-repo-guidelines.js"
+	],
 	"plugins": ["import", "node", "promise", "vitest"],
 	"options": { "denyWarnings": true },
 	"rules": {
@@ -17,7 +21,8 @@
 		"security/detect-object-injection": "error",
 		"security/detect-possible-timing-attacks": "error",
 		"security/detect-pseudoRandomBytes": "error",
-		"security/detect-unsafe-regex": "error"
+		"security/detect-unsafe-regex": "error",
+		"oxlint-repo-guidelines/no-more-docs": "error"
 	},
 	"overrides": [
 		{

--- a/scripts/oxlint-repo-guidelines.js
+++ b/scripts/oxlint-repo-guidelines.js
@@ -1,0 +1,80 @@
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+
+const ignoredDocDirs = new Set(['node_modules', '.git', 'dist', 'coverage', '.devin']);
+const allowedDocs = new Set([
+	'.github/PULL_REQUEST_TEMPLATE.md',
+	'AGENTS.md',
+	'LICENSE.md',
+	'README.md',
+	'assets/help.md',
+	'docs/ARCHITECTURE.md',
+	'docs/CHANGELOG.md',
+	'docs/CODE_OF_CONDUCT.md',
+	'docs/CONTRIBUTING.md',
+	'docs/SECURITY.md',
+]);
+const docsAnchorFile = path.resolve('src/index.ts');
+let docViolations;
+
+function* walkDocs(dir, prefix = '') {
+	// eslint-disable-next-line security/detect-non-literal-fs-filename
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const filePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+		if (entry.isDirectory()) {
+			if (!ignoredDocDirs.has(entry.name)) {
+				yield* walkDocs(`${dir}/${entry.name}`, filePath);
+			}
+		} else {
+			yield filePath;
+		}
+	}
+}
+
+function getDocViolations() {
+	if (docViolations) {
+		return docViolations;
+	}
+
+	const violations = [];
+	for (const file of walkDocs('.')) {
+		if (allowedDocs.has(file)) continue;
+		if (file.endsWith('.md') || file.startsWith('docs/')) {
+			violations.push(file);
+		}
+	}
+
+	docViolations = violations;
+	return violations;
+}
+
+const plugin = {
+	meta: {
+		name: 'oxlint-repo-guidelines',
+	},
+	rules: {
+		'no-more-docs': {
+			create(context) {
+				const filename = path.resolve(context.physicalFilename ?? context.filename ?? '');
+				if (filename !== docsAnchorFile) {
+					return {};
+				}
+
+				return {
+					Program(node) {
+						const violations = getDocViolations();
+						if (violations.length > 0) {
+							context.report({
+								message: `New docs/markdown files are not allowed: ${violations.join(', ')}`,
+								node,
+							});
+						}
+					},
+				};
+			},
+		},
+	},
+};
+
+export default plugin;


### PR DESCRIPTION
## Summary

**What**

Adds a custom oxlint plugin rule (`oxlint-repo-guidelines/no-more-docs`) that fails CI when new Markdown files or files under `docs/` are added beyond the existing allowlist.

**Why**

Keep the repository's documentation surface from growing unintentionally.

## Changes

- Added `scripts/oxlint-repo-guidelines.js` with the `no-more-docs` rule.
- Enabled the rule in `.oxlintrc.json`.

## Testing

How you verified this (commands, scenarios, or N/A):

- [ ] Automated tests (`bun run test`)
- [x] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

Manual checks:
- `bun run lint:ci` passes on the current repo.
- Creating `NEW_DOC.md` and running `bun run lint:ci` reports the violation and exits non-zero.

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

None.

**Focus areas for reviewers** (optional)

## Checklist

- [x] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
