### PR TITLE
feat: add --version/-V flag

### DIFF
--- a/assets/help.md
+++ b/assets/help.md
@@ -53,6 +53,7 @@ unless the `--force` option is used.
 Options:
 
 `--help`, `-h` Show this message
+`--version`, `-V` Show the version
 `--cache`, `-c` Only use local cache
 `--force`, `-f` Allow non-empty destination directory
 `--verbose`, `-v` Extra logging

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # degit changelog
 
+## 3.6.4
+
+- Add `--version` / `-V` flag to print the package version.
+
 ## 3.6.3
 
 - Accept full subdirectory URLs containing branch path segments such as `/tree/main/...` ([#370](https://github.com/Rich-Harris/degit/issues/370)).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.6.3",
+	"version": "3.6.4",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -23,6 +23,7 @@ type CliArgs = {
 	help?: boolean;
 	mode?: string;
 	verbose?: boolean;
+	version?: boolean;
 };
 
 type PromptResult = {
@@ -50,8 +51,9 @@ function parseCliArgs(argv: string[]) {
 			f: 'force',
 			m: 'mode',
 			v: 'verbose',
+			V: 'version',
 		},
-		boolean: ['force', 'cache', 'verbose'],
+		boolean: ['force', 'cache', 'verbose', 'version'],
 	}) as CliArgs;
 }
 
@@ -63,6 +65,21 @@ function displayHelp() {
 		.replaceAll(/`([^`]+)`/gu, (_match, value) => colors.cyan(value));
 
 	process.stdout.write(`\n${help}\n`);
+}
+
+function getVersion() {
+	for (const relativePath of ['../package.json', '../../package.json']) {
+		try {
+			const url = new URL(relativePath, import.meta.url);
+			const pkg = JSON.parse(fs.readFileSync(url, 'utf8')) as { version: string };
+
+			return pkg.version;
+		} catch {
+			// try next path
+		}
+	}
+
+	throw new Error('Could not find package.json');
 }
 
 function getInteractiveChoices(): Choice[] {
@@ -142,6 +159,11 @@ export async function main(argv: string[]) {
 
 	if (args.help) {
 		displayHelp();
+		return;
+	}
+
+	if (args.version) {
+		process.stdout.write(`${getVersion()}\n`);
 		return;
 	}
 

--- a/test/unit/bin.test.ts
+++ b/test/unit/bin.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import fs from 'node:fs';
 import assert from 'node:assert';
 import child_process from 'node:child_process';
@@ -104,6 +105,22 @@ describe('degit bin', () => {
 		}
 	}
 
+	async function captureMainStdout(args: string[]): Promise<string> {
+		const chunks: string[] = [];
+		const orig = process.stdout.write.bind(process.stdout);
+		process.stdout.write = ((chunk, enc, cb) => {
+			chunks.push(String(chunk));
+			cb?.();
+			return true;
+		}) as typeof process.stdout.write;
+		try {
+			await main(args);
+		} finally {
+			process.stdout.write = orig;
+		}
+		return chunks.join('');
+	}
+
 	const binTmp = '.tmp/bin-suite';
 	const repoRoot = process.cwd();
 	const rootBin = path.join(repoRoot, 'degit');
@@ -156,6 +173,34 @@ describe('degit bin', () => {
 		const out = chunks.join('');
 		assert.ok(out.length > 0);
 		assert.ok(out.includes('degit'));
+	});
+
+	const expectedVersion = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'))
+		.version as string;
+
+	it('prints version to stdout when argv includes --version', async () => {
+		const out = await captureMainStdout(['node', 'bin', '--version']);
+		assert.equal(out, `${expectedVersion}\n`);
+	});
+
+	it('prints version to stdout when argv includes -V', async () => {
+		const out = await captureMainStdout(['node', 'bin', '-V']);
+		assert.equal(out, `${expectedVersion}\n`);
+	});
+
+	it('runs the built root bin when a version flag is passed', () => {
+		for (const flag of ['--version', '-V']) {
+			const result = child_process.spawnSync('node', [rootBin, flag], {
+				env: {
+					...process.env,
+					VITEST: '',
+				},
+				encoding: 'utf8',
+			});
+			assert.equal(result.status, 0);
+			assert.equal(result.stderr, '');
+			assert.equal(result.stdout, `${expectedVersion}\n`);
+		}
 	});
 
 	it('invokes degit clone with options when argv supplies src and destination', async () => {


### PR DESCRIPTION
## Summary

**What**

Add a `--version` / `-V` CLI flag that prints the current package version and exits successfully.

**Why**

Users currently have no quick way to check which version of `degit` is installed. This is a small UX quick win that mirrors the existing `--help` behavior.

## Changes

- `src/bin.ts`: parse `--version` / `-V`, read the version from `package.json` at runtime using a source/dist-agnostic `import.meta.url` resolution, and print it to stdout.
- `assets/help.md`: list the new flag in the Options section.
- `test/unit/bin.test.ts`: add unit tests for `main(...)` and root-bin smoke tests for the built launcher.
- `docs/CHANGELOG.md`: add a `3.6.4` release note for the new flag.
- `package.json`: bump version to `3.6.4`.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [x] Manual / CLI check if user-facing behavior changed (`./degit --version` and `./degit -V`)
- [x] CI passes (`bun run typecheck`, `bun run lint:ci`, `bun run format:ci`)

## Review notes

**Breaking changes**

None.

**Risks / rollout**

- The version is read from `package.json` via `import.meta.url`. The helper tries both `../package.json` (built `dist/bin.js`) and `../../package.json` (source `src/bin.ts` during tests) so it works in both contexts.
- Uppercase `-V` was chosen because lowercase `-v` is already bound to `--verbose`.

**Focus areas for reviewers**

- Confirm the `import.meta.url` fallback is acceptable for the published package layout.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
