### PR TITLE
fix: resolve audit vulnerabilities in tar and postcss

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "mri": "1.1.6",
         "oxfmt": "0.47.0",
         "oxlint": "1.72.0",
-        "tar": "7.5.19",
+        "tar": "7.5.21",
         "tiny-glob": "0.2.8",
         "tsdown": "0.21.10",
         "typescript": "6.0.3",
@@ -30,7 +30,8 @@
     },
   },
   "overrides": {
-    "brace-expansion": "^1.1.16",
+    "brace-expansion": "1.1.16",
+    "postcss": "8.5.18",
     "vite": "8.0.16",
   },
   "packages": {
@@ -716,7 +717,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+    "postcss": ["postcss@8.5.18", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
@@ -834,7 +835,7 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "tar": ["tar@7.5.19", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw=="],
+    "tar": ["tar@7.5.21", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA=="],
 
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,6 +1,7 @@
 [install]
 minimumReleaseAge = 1209600
 exact = true
+minimumReleaseAgeExcludes = ["tar", "postcss"]
 
 [install.lockfile]
 saveTextLockfile = true

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"mri": "1.1.6",
 		"oxfmt": "0.47.0",
 		"oxlint": "1.72.0",
-		"tar": "7.5.19",
+		"tar": "7.5.21",
 		"tiny-glob": "0.2.8",
 		"tsdown": "0.21.10",
 		"typescript": "6.0.3",
@@ -74,7 +74,8 @@
 		"yoctocolors": "2.1.2"
 	},
 	"overrides": {
-		"brace-expansion": "^1.1.16",
+		"brace-expansion": "1.1.16",
+		"postcss": "8.5.18",
 		"vite": "8.0.16"
 	},
 	"lint-staged": {


### PR DESCRIPTION
## Summary

**What**

Resolve the current `bun audit` failures by bumping vulnerable dependencies and adding targeted `minimumReleaseAgeExcludes` so the patched versions can be installed despite the 14-day release-age gate.

**Why**

`master` currently fails `bun audit` with two advisories:
- `tar <=7.5.20` — GHSA-r292-9mhp-454m (moderate DoS in node-tar)
- `postcss <=8.5.17` via `vite` — GHSA-r28c-9q8g-f849 (high path traversal in source map auto-loading)

These block CI on new PRs.

## Changes

- `package.json`:
  - Bump `tar` from `7.5.19` to `7.5.21`.
  - Add `postcss` override pinned to `8.5.18`.
  - Pin `brace-expansion` override to exact `1.1.16` (was `^1.1.16`).
- `bunfig.toml`:
  - Add `minimumReleaseAgeExcludes = ["tar", "postcss"]` so the patched versions (still within the 14-day window) can be installed.
- `bun.lock`: regenerated.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [x] Manual / CLI check if user-facing behavior changed (N/A — dependency-only change)
- [x] CI passes (`bun run typecheck`, `bun run lint:ci`, `bun run format:ci`, `bun run audit`)

## Review notes

**Breaking changes**

None.

**Risks / rollout**

- The `minimumReleaseAgeExcludes` entries are scoped to `tar` and `postcss` only; the 14-day gate remains active for all other packages.
- Once these versions age past 14 days, the excludes can be removed.

**Focus areas for reviewers**

- Confirm the targeted excludes are acceptable as a temporary measure for security patches.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed (N/A)
- [x] Squashed to a single commit (or will be squashed on merge)
- [x] No unrelated drive-by changes
