### PR TITLE
feat: add repository aliases to CLI

### DIFF
--- a/assets/help.md
+++ b/assets/help.md
@@ -58,6 +58,17 @@ Options:
 `--force`, `-f` Allow non-empty destination directory
 `--verbose`, `-v` Extra logging
 
+Alias commands:
+
+`degit alias <repo> <name>` Save an alias for a repository
+`degit unalias <name>` Remove a saved alias
+`degit ls` List saved aliases
+
+Example:
+
+`degit alias github:user/repo myRepo`
+`degit myRepo` Equivalent to `degit github:user/repo`
+
 Private repositories are handled automatically: degit uses the tarball path by default for HTTPS sources and falls back to SSH cloning when needed. SSH/private repos still require git.
 
 `--mode=git` is still accepted for compatibility. `--mode=tar` is the default path and does not need special handling.

--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import colors from 'yoctocolors';
+import { base, mkdirp } from './shared/utils.js';
+
+export const aliasesFile = path.join(base, 'aliases.json');
+
+/* eslint-disable security/detect-non-literal-fs-filename */
+export function loadAliases(): Record<string, string> {
+	try {
+		return JSON.parse(fs.readFileSync(aliasesFile, 'utf8')) as Record<string, string>;
+	} catch {
+		return {};
+	}
+}
+
+function writeAliases(aliases: Record<string, string>) {
+	mkdirp(base);
+	fs.writeFileSync(aliasesFile, JSON.stringify(aliases, null, 2));
+}
+/* eslint-enable security/detect-non-literal-fs-filename */
+
+export function resolveAlias(aliases: Record<string, string>, name: string): string | undefined {
+	return Object.entries(aliases).find(([key]) => key === name)?.[1];
+}
+
+export function saveAlias(name: string, repo: string) {
+	const aliases = loadAliases();
+	const updated = { ...aliases, [name]: repo };
+	writeAliases(updated);
+}
+
+export function removeAlias(name: string): boolean {
+	const aliases = loadAliases();
+
+	if (!Object.hasOwn(aliases, name)) {
+		return false;
+	}
+
+	const updated = Object.fromEntries(Object.entries(aliases).filter(([key]) => key !== name));
+
+	if (Object.keys(updated).length === 0) {
+		fs.rmSync(aliasesFile, { force: true });
+	} else {
+		writeAliases(updated);
+	}
+
+	return true;
+}
+
+export function handleAliasSubcommand(args: string[]) {
+	const repo = args[1];
+	const name = args[2];
+
+	if (!repo || !name) {
+		console.error(colors.red('! usage: degit alias <repo> <name>'));
+		process.exit(1);
+	}
+
+	saveAlias(name, repo);
+	console.log(colors.green(`> added alias '${name}' -> ${repo}`));
+}
+
+export function handleUnaliasSubcommand(args: string[]) {
+	const name = args[1];
+
+	if (!name) {
+		console.error(colors.red('! usage: degit unalias <name>'));
+		process.exit(1);
+	}
+
+	if (!removeAlias(name)) {
+		console.error(colors.red(`! alias '${name}' not found`));
+		process.exit(1);
+	}
+
+	console.log(colors.green(`> removed alias '${name}'`));
+}
+
+export function handleListSubcommand() {
+	const aliases = loadAliases();
+	const entries = Object.entries(aliases).toSorted(([a], [b]) => a.localeCompare(b));
+
+	if (entries.length === 0) {
+		console.log('no aliases');
+		return;
+	}
+
+	for (const [name, repo] of entries) {
+		console.log(`${name} -> ${repo}`);
+	}
+}

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -6,6 +6,13 @@ import fuzzysearch from 'fuzzysearch';
 import mri from 'mri';
 import glob from 'tiny-glob/sync.js';
 import degit from './index.js';
+import {
+	handleAliasSubcommand,
+	handleListSubcommand,
+	handleUnaliasSubcommand,
+	loadAliases,
+	resolveAlias,
+} from './aliases.js';
 import { base, tryRequire } from './shared/utils.js';
 
 const dirname = import.meta.dirname;
@@ -37,6 +44,7 @@ type ForceResult = {
 };
 
 type RunArgs = {
+	aliases?: Record<string, string>;
 	cache?: boolean;
 	force?: boolean;
 	mode?: string;
@@ -152,6 +160,22 @@ async function confirmOverwrite(): Promise<boolean> {
 	return force;
 }
 
+async function handleInteractiveClone() {
+	const options = await promptForSource();
+
+	const empty = !fs.existsSync(options.dest) || fs.readdirSync(options.dest).length === 0;
+
+	if (!empty && !(await confirmOverwrite())) {
+		console.error(colors.magenta('! Directory not empty — aborting'));
+		return;
+	}
+
+	run(options.src, options.dest, {
+		cache: options.cache,
+		force: true,
+	});
+}
+
 export async function main(argv: string[]) {
 	const args = parseCliArgs(argv);
 
@@ -167,24 +191,28 @@ export async function main(argv: string[]) {
 		return;
 	}
 
-	if (!src) {
-		const options = await promptForSource();
-
-		const empty = !fs.existsSync(options.dest) || fs.readdirSync(options.dest).length === 0;
-
-		if (!empty && !(await confirmOverwrite())) {
-			console.error(colors.magenta('! Directory not empty — aborting'));
-			return;
-		}
-
-		run(options.src, options.dest, {
-			cache: options.cache,
-			force: true,
-		});
+	if (src === 'alias') {
+		handleAliasSubcommand(args._);
 		return;
 	}
 
-	run(src, dest, args);
+	if (src === 'unalias') {
+		handleUnaliasSubcommand(args._);
+		return;
+	}
+
+	if (src === 'ls') {
+		handleListSubcommand();
+		return;
+	}
+
+	if (!src) {
+		await handleInteractiveClone();
+		return;
+	}
+
+	const aliases = loadAliases();
+	run(resolveAlias(aliases, src) ?? src, dest, { ...args, aliases });
 }
 
 /* eslint-enable security/detect-non-literal-fs-filename */

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
 import colors from 'yoctocolors';
 import { parse, type Repo } from '../domain/repo.js';
+
+function resolveAlias(aliases: Record<string, string>, name: string): string | undefined {
+	return Object.entries(aliases).find(([key]) => key === name)?.[1];
+}
 import { applyDirectives } from '../operations/directives.js';
 import { checkDirIsEmpty, getDirectives, removeFiles } from '../operations/filesystem.js';
 import { cloneWithTar as cloneWithTarMode } from '../transports/tar/archive.js';
@@ -24,6 +28,7 @@ function cloneSuccessMessage(user: string, name: string, ref: string, dest: stri
 }
 
 export class Degit {
+	aliases: Record<string, string>;
 	cache?: boolean;
 	force?: boolean;
 	mode: ValidModes;
@@ -38,11 +43,12 @@ export class Degit {
 	private warnListeners: InfoListener[];
 
 	constructor(src: string, opts: ConstructorOptions = {}) {
+		this.aliases = opts.aliases ?? {};
 		this.cache = opts.cache;
 		this.force = opts.force;
 		this.verbose = opts.verbose;
 		this.proxy = process.env.https_proxy;
-		this.repo = parse(src);
+		this.repo = parse(resolveAlias(this.aliases, src) ?? src);
 		this.mode = opts.mode ?? this.repo.mode;
 		this.fetch = opts.fetch || fetch;
 		this.git = opts.git;

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -10,6 +10,7 @@ export const validModes = new Set(['tar', 'git']);
 export type FetchFn = (url: string, dest: string, proxy?: string) => Promise<void>;
 
 export type ConstructorOptions = {
+	aliases?: Record<string, string>;
 	cache?: boolean;
 	fetch?: FetchFn;
 	force?: boolean;

--- a/src/operations/directives.ts
+++ b/src/operations/directives.ts
@@ -19,6 +19,7 @@ type ChildDegit = {
 };
 
 type DirectiveContext = {
+	aliases?: Record<string, string>;
 	fetch: FetchFn;
 	getGitClient(): Promise<GitClient>;
 	hasStashed: boolean;
@@ -54,6 +55,7 @@ async function cloneDirective(
 	}
 
 	const child = createChild(action.src, {
+		aliases: context.aliases,
 		cache: action.cache,
 		fetch: context.fetch,
 		force: true,

--- a/test/unit/aliases.test.ts
+++ b/test/unit/aliases.test.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import assert from 'node:assert';
+import path from 'node:path';
+
+vi.mock('../../src/shared/utils.js', async () => {
+	const actual = await vi.importActual<typeof import('../../src/shared/utils.js')>(
+		'../../src/shared/utils.js',
+	);
+
+	return {
+		...actual,
+		base: path.join(process.cwd(), '.tmp', 'aliases-suite-cache'),
+	};
+});
+
+import { aliasesFile, loadAliases, removeAlias, saveAlias } from '../../src/aliases.js';
+import { base } from '../../src/shared/utils.js';
+
+/* eslint-disable max-lines-per-function */
+describe('aliases', () => {
+	beforeEach(() => {
+		fs.rmSync(base, { force: true, recursive: true });
+	});
+
+	afterEach(() => {
+		fs.rmSync(base, { force: true, recursive: true });
+	});
+
+	it('returns an empty object when the aliases file does not exist', () => {
+		assert.deepStrictEqual(loadAliases(), {});
+	});
+
+	it('returns an empty object when the aliases file contains invalid json', () => {
+		fs.mkdirSync(base, { recursive: true });
+		fs.writeFileSync(aliasesFile, 'not json');
+
+		assert.deepStrictEqual(loadAliases(), {});
+	});
+
+	it('saves a new alias when none exists', () => {
+		saveAlias('myRepo', 'github:user/repo');
+
+		assert.deepStrictEqual(loadAliases(), { myRepo: 'github:user/repo' });
+	});
+
+	it('adds an alias to the existing list when another alias already exists', () => {
+		saveAlias('first', 'github:user/first');
+		saveAlias('second', 'github:user/second');
+
+		assert.deepStrictEqual(loadAliases(), {
+			first: 'github:user/first',
+			second: 'github:user/second',
+		});
+	});
+
+	it('overwrites an existing alias when the same name is saved again', () => {
+		saveAlias('myRepo', 'github:user/old');
+		saveAlias('myRepo', 'github:user/new');
+
+		assert.deepStrictEqual(loadAliases(), { myRepo: 'github:user/new' });
+	});
+
+	it('returns true when an existing alias is removed', () => {
+		saveAlias('myRepo', 'github:user/repo');
+
+		assert.equal(removeAlias('myRepo'), true);
+		assert.deepStrictEqual(loadAliases(), {});
+	});
+
+	it('returns false when removing a non-existent alias', () => {
+		assert.equal(removeAlias('missing'), false);
+	});
+});

--- a/test/unit/bin.test.ts
+++ b/test/unit/bin.test.ts
@@ -42,6 +42,7 @@ vi.mock('enquirer', () => ({
 import { main, run } from '../../src/bin.js';
 import degit from '../../src/index.js';
 import { base } from '../../src/shared/utils.js';
+import { aliasesFile, saveAlias } from '../../src/aliases.js';
 import enquirer from 'enquirer';
 
 /* eslint-disable max-lines-per-function */
@@ -131,6 +132,7 @@ describe('degit bin', () => {
 	}
 	beforeEach(() => {
 		fs.rmSync(binTmp, { force: true, recursive: true });
+		fs.rmSync(aliasesFile, { force: true });
 		clearInteractiveFixtures();
 		vi.clearAllMocks();
 		mockDegit.mockReturnValue({
@@ -331,6 +333,95 @@ describe('degit bin', () => {
 		} finally {
 			warnSpy.mockRestore();
 		}
+	});
+
+	it('saves an alias when the alias subcommand is used', async () => {
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			await main(['node', 'bin', 'alias', 'github:user/repo', 'myRepo']);
+			assert.ok(String(logSpy.mock.calls[0][0]).includes("added alias 'myRepo'"));
+			assert.deepStrictEqual(
+				JSON.parse(fs.readFileSync(path.join(base, 'aliases.json'), 'utf8')),
+				{
+					myRepo: 'github:user/repo',
+				},
+			);
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it('prints usage and exits when the alias subcommand is missing arguments', async () => {
+		const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			await main(['node', 'bin', 'alias']);
+			assert.equal(exitSpy.mock.calls[0][0], 1);
+			assert.ok(String(errSpy.mock.calls[0][0]).includes('usage: degit alias'));
+		} finally {
+			exitSpy.mockRestore();
+			errSpy.mockRestore();
+		}
+	});
+
+	it('removes an alias when the unalias subcommand is used', async () => {
+		saveAlias('myRepo', 'github:user/repo');
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			await main(['node', 'bin', 'unalias', 'myRepo']);
+			assert.ok(String(logSpy.mock.calls[0][0]).includes("removed alias 'myRepo'"));
+			assert.equal(fs.existsSync(path.join(base, 'aliases.json')), false);
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it('prints not found and exits when unalias targets a missing alias', async () => {
+		const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			await main(['node', 'bin', 'unalias', 'missing']);
+			assert.equal(exitSpy.mock.calls[0][0], 1);
+			assert.ok(String(errSpy.mock.calls[0][0]).includes("alias 'missing' not found"));
+		} finally {
+			exitSpy.mockRestore();
+			errSpy.mockRestore();
+		}
+	});
+
+	it('lists saved aliases when the ls subcommand is used', async () => {
+		saveAlias('second', 'github:user/second');
+		saveAlias('first', 'github:user/first');
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			await main(['node', 'bin', 'ls']);
+			assert.equal(logSpy.mock.calls.length, 2);
+			assert.equal(String(logSpy.mock.calls[0][0]), 'first -> github:user/first');
+			assert.equal(String(logSpy.mock.calls[1][0]), 'second -> github:user/second');
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it('prints no aliases when the ls subcommand is used and none exist', async () => {
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			await main(['node', 'bin', 'ls']);
+			assert.equal(String(logSpy.mock.calls[0][0]), 'no aliases');
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it('resolves an alias to its repo when cloning', async () => {
+		saveAlias('myRepo', 'github:user/repo');
+		await main(['node', 'bin', 'myRepo', 'out']);
+		assert.equal(mockDegit.mock.calls[0][0], 'github:user/repo');
+	});
+
+	it('clones a repo named like a subcommand when given a site prefix', async () => {
+		await main(['node', 'bin', 'github:user/ls', 'out']);
+		assert.equal(mockDegit.mock.calls[0][0], 'github:user/ls');
 	});
 });
 /* eslint-enable max-lines-per-function */


### PR DESCRIPTION
## Summary

Implements repository aliases for the degit CLI, as requested in #362.

- `degit alias <repo> <name>` saves an alias.
- `degit <name>` resolves the alias and clones the stored repo.
- `degit ls` lists saved aliases.
- `degit unalias <name>` removes an alias.

Aliases are persisted in the platform cache directory as `aliases.json`. The optional `aliases` option is also added to `ConstructorOptions` so the library can resolve aliases when used programmatically.

## Changes

- Added `src/aliases.ts` for persistence and CLI command helpers.
- Added `aliases?: Record<string, string>` to `ConstructorOptions`.
- Updated `Degit` to resolve aliases before parsing the source string.
- Updated `src/bin.ts` to handle `alias`, `unalias`, and `ls` subcommands.
- Updated `src/operations/directives.ts` to forward the alias map to child clones created by `degit.json` directives.
- Updated `assets/help.md` with alias usage.
- Added unit tests for persistence and CLI behavior.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint:ci` passes
- [x] `bun run format:ci` passes
- [x] `bun run test` passes (122 tests)
- [x] Manual smoke test: add alias, list, remove

Generated with [Devin](https://devin.ai)