### PR TITLE
fix: respect repo.subdir and report correct mode in git mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add repository aliases to the CLI ([#362](https://github.com/Rich-Harris/degit/issues/362)).
+- Respect `repo.subdir` and report the correct `mode` when using `mode: 'git'` ([#349](https://github.com/Rich-Harris/degit/issues/349)).
 
 ## 3.6.4
 

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,3 +1,4 @@
+import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
 import colors from 'yoctocolors';
 import { parse, type Repo } from '../domain/repo.js';
@@ -6,7 +7,12 @@ function resolveAlias(aliases: Record<string, string>, name: string): string | u
 	return Object.entries(aliases).find(([key]) => key === name)?.[1];
 }
 import { applyDirectives } from '../operations/directives.js';
-import { checkDirIsEmpty, getDirectives, removeFiles } from '../operations/filesystem.js';
+import {
+	checkDirIsEmpty,
+	copyRepoSubdir,
+	getDirectives,
+	removeFiles,
+} from '../operations/filesystem.js';
 import { cloneWithTar as cloneWithTarMode } from '../transports/tar/archive.js';
 import {
 	validModes,
@@ -50,6 +56,7 @@ export class Degit {
 		this.proxy = process.env.https_proxy;
 		this.repo = parse(resolveAlias(this.aliases, src) ?? src);
 		this.mode = opts.mode ?? this.repo.mode;
+		this.repo = { ...this.repo, mode: this.mode };
 		this.fetch = opts.fetch || fetch;
 		this.git = opts.git;
 		this.hasStashed = false;
@@ -202,6 +209,21 @@ export class Degit {
 		await (await this.getGitClient()).clone(this.repo, dest, ref, this.repo.transport);
 	}
 
+	async cloneGitToDestination(dest: string, ref = this.repo.ref): Promise<void> {
+		if (this.repo.subdir) {
+			const tmp = await mkdtemp('degit-git-');
+			try {
+				await this.cloneWithGit(tmp, ref);
+				copyRepoSubdir(tmp, dest, this.repo.subdir);
+			} finally {
+				await rm(tmp, { force: true, recursive: true });
+			}
+			return;
+		}
+
+		await this.cloneWithGit(dest, ref);
+	}
+
 	shouldFallbackToGit(error: unknown): boolean {
 		if (!error || typeof error !== 'object') {
 			return false;
@@ -225,7 +247,7 @@ export class Degit {
 	private async cloneToDestination(dest: string) {
 		if (this.mode === 'git') {
 			const hash = await this.getHash(this.repo, {});
-			await this.cloneWithGit(dest, hash || this.repo.ref);
+			await this.cloneGitToDestination(dest, hash || this.repo.ref);
 			return;
 		}
 
@@ -239,7 +261,7 @@ export class Degit {
 			this.warn({
 				message: `tar snapshot download or extraction failed; falling back to git clone`,
 			});
-			await this.cloneWithGit(dest);
+			await this.cloneGitToDestination(dest);
 		}
 	}
 

--- a/src/operations/filesystem.ts
+++ b/src/operations/filesystem.ts
@@ -103,4 +103,24 @@ function removeFile(root: string, file: string, warn: Emit) {
 	return [file];
 }
 
+export function copyRepoSubdir(srcDir: string, dest: string, subdir: string) {
+	const normalized = subdir.replace(/^\/+|\/+$/gu, '');
+	const source = path.join(srcDir, normalized);
+
+	if (!fs.existsSync(source)) {
+		throw new DegitError(`could not find subdirectory ${subdir} in cloned repository`, {
+			code: 'MISSING_SUBDIR',
+			subdir,
+		});
+	}
+
+	fs.mkdirSync(dest, { recursive: true });
+
+	for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+		const srcPath = path.join(source, entry.name);
+		const destPath = path.join(dest, entry.name);
+		fs.cpSync(srcPath, destPath, { recursive: true });
+	}
+}
+
 /* eslint-enable security/detect-non-literal-fs-filename */

--- a/test/unit/index-git-suites.test.ts
+++ b/test/unit/index-git-suites.test.ts
@@ -12,7 +12,8 @@ import {
 	clearArchiveCache,
 	gitRefs,
 } from './index-support.js';
-import { createMockGit } from '../helpers.js';
+import { createMockFetch, createMockGit } from '../helpers.js';
+import type { Repo } from '../../src/domain/repo.js';
 
 const { suiteCache, suiteTmp } = vi.hoisted(() => ({
 	suiteCache: '.tmp/index-git-suite-cache',
@@ -127,6 +128,111 @@ describe('degit index git suites', () => {
 			expect(fs.existsSync(archiveFile)).toBe(true);
 			await cloneAndExpectGitFallback(test, archiveFile, dest);
 		});
+	});
+
+	function createFileWritingGitMock(files: Record<string, string>) {
+		return {
+			fetchRefs(_repo: Repo) {
+				return Promise.resolve(gitRefs);
+			},
+			clone(_repo: Repo, cloneDest: string) {
+				for (const [file, content] of Object.entries(files)) {
+					const filePath = path.join(cloneDest, file);
+					fs.mkdirSync(path.dirname(filePath), { recursive: true });
+					fs.writeFileSync(filePath, content);
+				}
+				return Promise.resolve();
+			},
+		};
+	}
+
+	it('sets repo.mode to git in the instance when mode is git', () => {
+		const emitter = degit('Rich-Harris/degit-test-repo', { mode: 'git' });
+		assert.equal(emitter.repo.mode, 'git');
+	});
+
+	it('defaults repo.mode to tar when no mode is provided', () => {
+		const emitter = degit('Rich-Harris/degit-test-repo');
+		assert.equal(emitter.repo.mode, 'tar');
+	});
+
+	it('extracts only the subdirectory when mode is git with subdir', async () => {
+		const test = providerCases[0];
+		const dest = `${suiteTmp}/git-subdir`;
+		const gitMock = createFileWritingGitMock({
+			'packages/app/index.js': 'export default 1\n',
+			'README.md': 'hello',
+		});
+
+		await degit(`${test.publicSrc}/packages/app`, {
+			git: gitMock,
+			mode: 'git',
+		}).clone(dest);
+
+		assert.equal(fs.existsSync(path.join(dest, 'index.js')), true);
+		assert.equal(fs.readFileSync(path.join(dest, 'index.js'), 'utf8'), 'export default 1\n');
+		assert.equal(fs.existsSync(path.join(dest, 'README.md')), false);
+		assert.equal(fs.existsSync(path.join(dest, 'packages')), false);
+	});
+
+	it('throws MISSING_SUBDIR when the subdirectory does not exist in git mode', async () => {
+		const test = providerCases[0];
+		const dest = `${suiteTmp}/git-missing-subdir`;
+		const gitMock = createFileWritingGitMock({
+			'README.md': 'hello',
+		});
+
+		await assert.rejects(
+			degit(`${test.publicSrc}/packages/app`, {
+				git: gitMock,
+				mode: 'git',
+			}).clone(dest),
+			(err: unknown) => (err as { code?: string }).code === 'MISSING_SUBDIR',
+		);
+	});
+
+	it('clones the full repository in git mode when no subdirectory is requested', async () => {
+		const test = providerCases[0];
+		const dest = `${suiteTmp}/git-no-subdir`;
+		const gitMock = createFileWritingGitMock({
+			'packages/app/index.js': 'export default 1\n',
+			'README.md': 'hello',
+		});
+
+		await degit(test.publicSrc, {
+			git: gitMock,
+			mode: 'git',
+		}).clone(dest);
+
+		assert.equal(fs.existsSync(path.join(dest, 'README.md')), true);
+		assert.equal(fs.existsSync(path.join(dest, 'packages/app/index.js')), true);
+	});
+
+	it('extracts only the subdirectory when tar falls back to git', async () => {
+		const test = providerCases[0];
+		const dest = `${suiteTmp}/tar-fallback-subdir`;
+		clearArchiveCache(suiteCache, test);
+		const fetchMock = createMockFetch([
+			{
+				code: 'COULD_NOT_DOWNLOAD',
+				message: 'not found',
+				status: 404,
+			},
+		]);
+		const gitMock = createFileWritingGitMock({
+			'packages/app/index.js': 'export default 1\n',
+			'README.md': 'hello',
+		});
+
+		await degit(`${test.publicSrc}/packages/app`, {
+			cache: false,
+			fetch: fetchMock.fn,
+			git: gitMock,
+		}).clone(dest);
+
+		assert.equal(fs.existsSync(path.join(dest, 'index.js')), true);
+		assert.equal(fs.readFileSync(path.join(dest, 'index.js'), 'utf8'), 'export default 1\n');
+		assert.equal(fs.existsSync(path.join(dest, 'README.md')), false);
 	});
 });
 /* eslint-enable max-lines-per-function */


### PR DESCRIPTION
## Summary

**What**

Make `mode: 'git'` respect `repo.subdir` and report the actual mode in the `SUCCESS` event.

**Why**

Issue #349 reports that the JS API clones the entire repository when `mode: 'git'` is combined with a subdirectory, and that the emitted event always shows `"mode": "tar"`.

## Linked issues

Closes #349

## Changes

- Added `copyRepoSubdir()` to `src/operations/filesystem.ts` to copy a subdirectory from a cloned repository into the destination, throwing `MISSING_SUBDIR` when it is absent.
- Added `cloneGitToDestination()` to `src/core/orchestrator.ts`: when `repo.subdir` is set, it clones into a temporary directory and then copies only that subdirectory into `dest`; otherwise it keeps the existing direct clone behavior.
- Routed both direct git mode and tar-to-git fallback through `cloneGitToDestination()` so subdirectory extraction also works on fallback.
- Updated the `Degit` constructor to set `this.repo.mode` to the resolved mode so the `SUCCESS` event reports `'git'` or `'tar'` correctly.
- Added unit tests covering git mode with subdir, missing subdir, no-subdir regression, tar fallback with subdir, and the reported `repo.mode`.
- Added an unreleased changelog note.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [x] CI passes (`bun run typecheck`, `bun run lint:ci`, `bun run format:ci`)

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

- New subdirectory extraction uses `node:fs/promises` temp directory operations; behavior mirrors the existing tar archive extraction path.
- The emitted `repo.mode` now reflects the resolved mode (`'git'` or `'tar'`), which matches user intent and the options passed to `degit()`.

**Focus areas for reviewers** (optional)

- Confirm `copyRepoSubdir()` handles edge cases like `dest === '.'` and non-existent subdirectories.
- Verify the temporary directory cleanup in `cloneGitToDestination()`.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
