### PR TITLE
fix: return empty choices when cache directory does not exist

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix interactive mode crash when the cache directory does not exist ([#345](https://github.com/Rich-Harris/degit/issues/345)).
 - Add repository aliases to the CLI ([#362](https://github.com/Rich-Harris/degit/issues/362)).
 - Respect `repo.subdir` and report the correct `mode` when using `mode: 'git'` ([#349](https://github.com/Rich-Harris/degit/issues/349)).
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -91,6 +91,8 @@ function getVersion() {
 }
 
 function getInteractiveChoices(): Choice[] {
+	if (!fs.existsSync(base)) return [];
+
 	const accessLookup = new Map<string, number>();
 
 	glob('**/access.json', { cwd: base }).forEach((file) => {

--- a/test/unit/bin.test.ts
+++ b/test/unit/bin.test.ts
@@ -214,6 +214,25 @@ describe('degit bin', () => {
 		assert.equal(instance.clone.mock.calls[0][0], 'out');
 	});
 
+	it('presents empty choices when the cache directory does not exist', async () => {
+		fs.rmSync(base, { force: true, recursive: true });
+
+		mockPrompt.mockImplementation((questions) => {
+			const srcQuestion = (
+				questions as Array<{ name?: string; choices?: Array<{ value: string }> }>
+			).find((question) => question.name === 'src');
+			assert.ok(srcQuestion);
+			assert.deepEqual(srcQuestion.choices, []);
+			return Promise.resolve({
+				cache: false,
+				dest: '.tmp/bin-suite/from-interactive',
+				src: '',
+			});
+		});
+
+		await main(['node', 'bin']);
+	});
+
 	it('ranks interactive repo choices by most recent access when argv omits src', async () => {
 		const recentRepo = path.join(base, 'github', 'user-b', 'repo-b');
 		const olderRepo = path.join(base, 'github', 'user-a', 'repo-a');


### PR DESCRIPTION
## Summary

**What**

Guard `getInteractiveChoices()` with an `fs.existsSync(base)` check so it returns an empty list when the cache directory does not yet exist.

**Why**

Running bare `degit` (no arguments, interactive mode) crashes with `ENOENT: no such file or directory, scandir '…/degit'` on first use because `tiny-glob` tries to scan a cache directory that hasn't been created yet.

## Linked issues

Closes #345

## Changes

- `src/bin.ts`: Return `[]` early from `getInteractiveChoices()` when `base` does not exist.
- `test/unit/bin.test.ts`: Add test that verifies interactive mode presents empty choices when the cache directory is missing.
- `docs/CHANGELOG.md`: Add unreleased entry.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [x] Manual / CLI check if user-facing behavior changed
- [x] CI passes

Reproduced with `HOME=$(mktemp -d)/home node dist/bin.js` — confirmed ENOENT before the fix and clean interactive prompt after.

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

None — the only behavioral change is that the interactive chooser shows no previous repos instead of crashing.

**Focus areas for reviewers** (optional)

The one-line guard in `getInteractiveChoices()`.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
