### PR TITLE
chore(release): 3.6.5

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
+## 3.6.5
+
 - Fix interactive mode crash when the cache directory does not exist ([#345](https://github.com/Rich-Harris/degit/issues/345)).
 - Add repository aliases to the CLI ([#362](https://github.com/Rich-Harris/degit/issues/362)).
 - Respect `repo.subdir` and report the correct `mode` when using `mode: 'git'` ([#349](https://github.com/Rich-Harris/degit/issues/349)).
+- Throw an error instead of creating an empty destination when the requested subdirectory does not exist in git mode ([#331](https://github.com/Rich-Harris/degit/issues/331)).
 
 ## 3.6.4
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.6.4",
+	"version": "3.6.5",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",


### PR DESCRIPTION
## Summary

**What**

Bumps the package version to `3.6.5` and finalizes the changelog for the release.

**Why**

The current `HEAD` contains unreleased fixes, including the git-mode subdirectory handling fix. The latest published npm release (`3.6.4`) still silently clones the entire repository when a subdirectory is requested in git mode, which is the root cause of #331.

## Linked issues

Closes #331

## Changes

- `package.json`: bump version from `3.6.4` to `3.6.5`
- `docs/CHANGELOG.md`: move unreleased entries into a new `3.6.5` section and add the #331 fix note

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [x] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

`bun run test` passed (129 tests, 11 files). I also verified with `npx degit@latest` that `3.6.4` still exhibits the bug in git mode, while the current source/this branch does not.

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

Low. This is a pure metadata/changelog release; no source code is changed. Once merged, a `v3.6.5` tag will trigger the `publish.yml` workflow and publish to npm.

**Focus areas for reviewers** (optional)

- Confirm the changelog accurately reflects the unreleased commits on `master`.
- Confirm the version bump matches the intended release.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
