### PR TITLE
docs: clarify cache option and offline fallback behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ degit https://github.com/user/repo/tree/main/subdirectory
 
 If you have an `https_proxy` environment variable, Degit will use it.
 
+### Cache behavior
+
+degit caches downloaded tar snapshots so you don't need to fetch them again. By default, it tries to resolve the latest ref from the network and falls back to the cached version if the network is unreachable. Use `--cache` (`-c`) to skip the network request entirely and only use a locally cached copy.
+
 ### Private repositories
 
 Private repositories are handled automatically. degit uses the tarball path by default for HTTPS sources and falls back to SSH cloning when it cannot fetch or extract a snapshot.

--- a/assets/help.md
+++ b/assets/help.md
@@ -54,9 +54,11 @@ Options:
 
 `--help`, `-h` Show this message
 `--version`, `-V` Show the version
-`--cache`, `-c` Only use local cache
+`--cache`, `-c` Only use local cache (no network)
 `--force`, `-f` Allow non-empty destination directory
 `--verbose`, `-v` Extra logging
+
+Without `--cache`, degit tries the network first and falls back to the local cache if the network is unreachable.
 
 Alias commands:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 3.6.6
-
 - Clarify `--cache` flag and default offline fallback behavior in help text and README ([#314](https://github.com/Rich-Harris/degit/issues/314)).
 
 ## 3.6.5

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 3.6.6
+
+- Clarify `--cache` flag and default offline fallback behavior in help text and README ([#314](https://github.com/Rich-Harris/degit/issues/314)).
+
 ## 3.6.5
 
 - Fix interactive mode crash when the cache directory does not exist ([#345](https://github.com/Rich-Harris/degit/issues/345)).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.6.5",
+	"version": "3.6.6",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.6.6",
+	"version": "3.6.5",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",

--- a/skills/degit/SKILL.md
+++ b/skills/degit/SKILL.md
@@ -17,7 +17,7 @@ npx degit@latest user/repo#branch my-project
 Sources can be GitHub (`user/repo`, `github:user/repo`, or a GitHub URL), GitLab (`gitlab:user/repo`, a GitLab URL, or `gitlab://host/user/repo`), Bitbucket (`bitbucket:user/repo` or URL), or Sourcehut (`git.sr.ht/user/repo`, SSH form, or URL). A `#ref` can name a branch, tag, or commit. A source may include a subdirectory path.
 
 - The destination defaults to the current directory and must be empty. Do not suggest `--force` unless the user explicitly wants to overwrite its contents.
-- Use `--cache` to require a cached copy and `--verbose` to diagnose failures. `--mode=git` still works but is unnecessary; tar snapshots are the default.
+- Use `--cache` to require a cached copy (no network). Without `--cache`, degit tries the network first and falls back to the cached copy if the network is unreachable. Use `--verbose` to diagnose failures. `--mode=git` still works but is unnecessary; tar snapshots are the default.
 - Private repositories are handled automatically, with SSH fallback when needed. SSH/private use requires `git` on `PATH` and working repository credentials.
 - For reusable shortcuts, use `degit alias <repo> <name>`, then `degit <name>`; use `degit ls` and `degit unalias <name>` to manage aliases.
 - If a template needs post-download changes, explain that its top-level `degit.json` can use `clone`, `search_replace`, and `remove` actions. `search_replace` uses a named environment variable for its replacement value.


### PR DESCRIPTION
## Summary

**What**

Clarifies that `--cache` skips the network entirely, while the default mode still falls back to the local cache when offline.

**Why**

Issue #314 asked whether offline operation with `cache:false` is expected. The current help text and README describe `--cache` as "Only use local cache" but don't explain that the default path also uses the cache as a fallback when the network is unreachable.

## Linked issues

Closes #314

## Changes

- `assets/help.md`: expanded `--cache` description and added a note about the default offline fallback.
- `README.md`: added a "Cache behavior" subsection under Usage.
- `skills/degit/SKILL.md`: updated the `--cache` guidance for agents.
- `docs/CHANGELOG.md`: added unreleased note.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [x] Manual / CLI check if user-facing behavior changed (docs only; `bun run format:ci` passed)
- [ ] CI passes

## Review notes

**Breaking changes**

None.

**Risks / rollout**

None.

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [ ] Squashed to a single commit (kept as separate commits to avoid force-pushing a shared branch; happy to squash if reviewer prefers)
- [x] No unrelated drive-by changes
