### PR TITLE
docs: add JSON Schema for degit.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ emitter.clone('path/to/dest').then(() => {
 
 You can manipulate repositories after they have been cloned with _actions_, specified in a `degit.json` file that lives at the top level of the working directory. Currently, there are three actions — `clone`, `search_replace`, and `remove`. Additional actions may be added in future.
 
+A [JSON Schema](schemas/degit.schema.json) is available for editor autocompletion and validation; map `degit.json` to it in your editor's JSON schema settings (e.g. VS Code's `json.schemas`).
+
 ### clone
 
 ```json

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Clarify `--cache` flag and default offline fallback behavior in help text and README ([#314](https://github.com/Rich-Harris/degit/issues/314)).
+- Add a JSON Schema for `degit.json` at `schemas/degit.schema.json`.
 
 ## 3.6.5
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 		"dist",
 		"docs/CHANGELOG.md",
 		"LICENSE.md",
-		"README.md"
+		"README.md",
+		"schemas"
 	],
 	"type": "module",
 	"main": "dist/index.js",

--- a/schemas/degit.schema.json
+++ b/schemas/degit.schema.json
@@ -1,0 +1,75 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://raw.githubusercontent.com/Rich-Harris/degit/master/schemas/degit.schema.json",
+	"title": "degit.json",
+	"description": "Post-clone actions for degit, specified in a degit.json file at the top level of the working directory. See https://github.com/Rich-Harris/degit#actions.",
+	"type": "array",
+	"items": {
+		"oneOf": [
+			{ "$ref": "#/$defs/clone" },
+			{ "$ref": "#/$defs/searchReplace" },
+			{ "$ref": "#/$defs/remove" }
+		]
+	},
+	"$defs": {
+		"clone": {
+			"type": "object",
+			"title": "clone",
+			"description": "Clone another repository into the working directory, preserving its existing contents.",
+			"additionalProperties": false,
+			"required": ["action", "src"],
+			"properties": {
+				"action": { "const": "clone" },
+				"src": {
+					"type": "string",
+					"description": "The repository to clone, in the same format accepted by the degit CLI (e.g. user/repo)."
+				},
+				"cache": {
+					"type": "boolean",
+					"description": "Use a cached version of the repository if available."
+				},
+				"verbose": {
+					"type": "boolean",
+					"description": "Show extra information about the clone."
+				}
+			}
+		},
+		"searchReplace": {
+			"type": "object",
+			"title": "search_replace",
+			"description": "Replace every match of a regular expression in the listed files.",
+			"additionalProperties": false,
+			"required": ["action", "files", "pattern", "replacement"],
+			"properties": {
+				"action": { "const": "search_replace" },
+				"files": { "$ref": "#/$defs/files" },
+				"pattern": {
+					"type": "string",
+					"description": "A regular expression (as a string) to match within each file."
+				},
+				"replacement": {
+					"type": "string",
+					"description": "The name of an environment variable whose value replaces each match."
+				}
+			}
+		},
+		"remove": {
+			"type": "object",
+			"title": "remove",
+			"description": "Remove one or more files from the working directory.",
+			"additionalProperties": false,
+			"required": ["action", "files"],
+			"properties": {
+				"action": { "const": "remove" },
+				"files": { "$ref": "#/$defs/files" }
+			}
+		},
+		"files": {
+			"description": "A single path or an array of paths, resolved relative to the destination. Paths outside the destination are skipped.",
+			"oneOf": [
+				{ "type": "string" },
+				{ "type": "array", "items": { "type": "string" }, "minItems": 1 }
+			]
+		}
+	}
+}


### PR DESCRIPTION
## Summary

**What**

Adds `schemas/degit.schema.json`, a Draft 2020-12 JSON Schema for `degit.json` covering the `clone`, `search_replace`, and `remove` actions. Links it from the README and ships it with the published package (`files` in `package.json`).

**Why**

Makes it possible for editors to validate and autocomplete `degit.json` (e.g. via VS Code json.schemas setting, or once submitted to SchemaStore).

## Linked issues

## Changes

- Add `schemas/degit.schema.json`
- Document the schema and how to map it in an editor in the README
- Ship `schemas/` in the published npm package
- Add an Unreleased changelog entry

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [x] Manual / CLI check if user-facing behavior changed (`python3 -m json.tool` to validate the schema is well-formed JSON; manually checked it matches the existing clone/search_replace/remove examples in the README)
- [ ] CI passes

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

None, docs/schema addition only, no runtime behavior change.

**Focus areas for reviewers** (optional)

Whether the schema $id (`https://raw.githubusercontent.com/Rich-Harris/degit/master/schemas/degit.schema.json`) is the right convention before it is submitted to SchemaStore.

## Checklist

- [x] Error paths and exit codes considered where relevant (N/A, no runtime code changed)
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
