### PR TITLE
fix(parse): decode src before parsing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support GitLab nested groups by probing candidate `user/repo` paths at runtime ([#76](https://github.com/Rich-Harris/degit/issues/76)).
 - Clarify `--cache` flag and default offline fallback behavior in help text and README ([#314](https://github.com/Rich-Harris/degit/issues/314)).
 - Add a JSON Schema for `degit.json` at `schemas/degit.schema.json`.
+- Decode URL-encoded subdirectory segments in full repository URLs ([#477](https://github.com/Rich-Harris/degit/issues/477)).
 
 ## 3.6.5
 

--- a/src/domain/repo.ts
+++ b/src/domain/repo.ts
@@ -163,7 +163,10 @@ function parseWebPath(
 export function parse(src: string): Repo {
 	const decodedSrc = decodeURIComponent(src);
 	const [source, refValue = 'HEAD'] = decodedSrc.split('#', 2);
-	const { remainder, site, transport, customDomain, isWebUrl } = resolveSource(source, decodedSrc);
+	const { remainder, site, transport, customDomain, isWebUrl } = resolveSource(
+		source,
+		decodedSrc,
+	);
 
 	if (!supported.has(site)) {
 		throw new DegitError(`degit supports GitHub, GitLab, Sourcehut and BitBucket`, {

--- a/src/domain/repo.ts
+++ b/src/domain/repo.ts
@@ -161,9 +161,9 @@ function parseWebPath(
 }
 
 export function parse(src: string): Repo {
-	src = decodeURIComponent(src);
-	const [source, refValue = 'HEAD'] = src.split('#', 2);
-	const { remainder, site, transport, customDomain, isWebUrl } = resolveSource(source, src);
+	const decodedSrc = decodeURIComponent(src);
+	const [source, refValue = 'HEAD'] = decodedSrc.split('#', 2);
+	const { remainder, site, transport, customDomain, isWebUrl } = resolveSource(source, decodedSrc);
 
 	if (!supported.has(site)) {
 		throw new DegitError(`degit supports GitHub, GitLab, Sourcehut and BitBucket`, {

--- a/src/domain/repo.ts
+++ b/src/domain/repo.ts
@@ -161,6 +161,7 @@ function parseWebPath(
 }
 
 export function parse(src: string): Repo {
+	src = decodeURIComponent(src);
 	const [source, refValue = 'HEAD'] = src.split('#', 2);
 	const { remainder, site, transport, customDomain, isWebUrl } = resolveSource(source, src);
 

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -79,6 +79,12 @@ describe('degit index', () => {
 		assert.equal(repo.url, 'https://github.com/TanStack/table');
 		assert.equal(repo.ssh, 'ssh://git@github.com/TanStack/table');
 	});
+	it('decodes a URL-encoded subdirectory segment into @types when the URL contains %40types', () => {
+		const repo = parse('https://github.com/user/repo/tree/main/%40types');
+
+		assert.equal(repo.ref, 'main');
+		assert.equal(repo.subdir, '/@types');
+	});
 	it('parses a full GitHub tree URL into only a ref when no subdirectory is given', () => {
 		const repo = parse('https://github.com/user/repo/tree/main');
 


### PR DESCRIPTION
## Summary
**What**
Decode the URL/src before parsing to get correct `subdir` 
**Why**
Fix - https://github.com/Rich-Harris/degit/issues/477. The PR fixes parsed subdir from `%40types` to `@types`

## Linked issues
https://github.com/Rich-Harris/degit/issues/477
<!-- Optional: `Closes #<issue-number>` so the issue is closed automatically when this PR is merged. -->

## Changes
Decode `src` using `decodeURIComponent(src);` on `src\domain\repo.ts:parse`
## Testing

How you verified this (commands, scenarios, or N/A):
- [x] Automated tests (`bun run test`)
- [x] Manual / CLI check if user-facing behavior changed
- [ ] CI passes

## Review notes

**Breaking changes** (or none)

**Risks / rollout** (or none)

**Focus areas for reviewers** (optional)

## Checklist

- [ ] Error paths and exit codes considered where relevant
- [ ] Help text, completions, or docs updated if user-facing strings changed
- [ ] Squashed to a single commit
- [ ] No unrelated drive-by changes
