### PR TITLE
feat: add files option to clone only selected files or directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ You can also paste a full GitHub URL to a subdirectory:
 degit https://github.com/user/repo/tree/main/subdirectory
 ```
 
+### Clone specific files
+
+To clone only specific files or directories, use `--files` or `-F`. Separate paths with commas or repeat the flag:
+
+```bash
+degit user/repo my-project --files README.md,src/index.ts
+degit user/repo my-project -F README.md -F src/index.ts
+```
+
+You can also use the `files` option with the ESM API:
+
+```js
+const emitter = degit('user/repo', {
+	files: ['README.md', 'src/index.ts'],
+});
+```
+
+Paths are resolved relative to the destination. Missing or out-of-bounds paths are skipped with a warning; if no requested paths resolve, the whole destination is kept.
+
 ### GitLab nested groups
 
 GitLab repositories inside nested groups are supported at runtime:
@@ -185,6 +204,11 @@ A [JSON Schema](schemas/degit.schema.json) is available for editor autocompletio
 	{
 		"action": "clone",
 		"src": "user/another-repo"
+	},
+	{
+		"action": "clone",
+		"src": "user/another-repo",
+		"files": ["README.md", "src/index.ts"]
 	}
 ]
 ```

--- a/assets/help.md
+++ b/assets/help.md
@@ -56,6 +56,7 @@ Options:
 `--version`, `-V` Show the version
 `--cache`, `-c` Only use local cache (no network)
 `--force`, `-f` Allow non-empty destination directory
+`--files <paths>`, `-F <paths>` Clone only the listed files or directories (comma-separated)
 `--verbose`, `-v` Extra logging
 
 Without `--cache`, degit tries the network first and falls back to the local cache if the network is unreachable.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Redownload cached tar archives when extraction fails with any tar/zlib error, not only `TAR_BAD_ARCHIVE` ([#41](https://github.com/Rich-Harris/degit/issues/41)).
+- Added `files` option to clone only specific files or directories ([#129](https://github.com/Rich-Harris/degit/issues/129)).
 
 ## 3.6.6
 

--- a/schemas/degit.schema.json
+++ b/schemas/degit.schema.json
@@ -28,6 +28,10 @@
 					"type": "boolean",
 					"description": "Use a cached version of the repository if available."
 				},
+				"files": {
+					"$ref": "#/$defs/files",
+					"description": "Only keep these files or directories from the cloned repository."
+				},
 				"verbose": {
 					"type": "boolean",
 					"description": "Show extra information about the clone."

--- a/skills/degit/SKILL.md
+++ b/skills/degit/SKILL.md
@@ -18,6 +18,7 @@ Sources can be GitHub (`user/repo`, `github:user/repo`, or a GitHub URL), GitLab
 
 - The destination defaults to the current directory and must be empty. Do not suggest `--force` unless the user explicitly wants to overwrite its contents.
 - Use `--cache` to require a cached copy (no network). Without `--cache`, degit tries the network first and falls back to the cached copy if the network is unreachable. Use `--verbose` to diagnose failures. `--mode=git` still works but is unnecessary; tar snapshots are the default.
+- Use `--files <paths>` or `-F <paths>` to clone only specific files or directories; separate multiple paths with commas or repeat the flag.
 - Private repositories are handled automatically, with SSH fallback when needed. SSH/private use requires `git` on `PATH` and working repository credentials.
 - For reusable shortcuts, use `degit alias <repo> <name>`, then `degit <name>`; use `degit ls` and `degit unalias <name>` to manage aliases.
 - If a template needs post-download changes, explain that its top-level `degit.json` can use `clone`, `search_replace`, and `remove` actions. `search_replace` uses a named environment variable for its replacement value.

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -26,6 +26,7 @@ type Choice = {
 type CliArgs = {
 	_: string[];
 	cache?: boolean;
+	files?: string | string[] | boolean;
 	force?: boolean;
 	help?: boolean;
 	mode?: string;
@@ -46,6 +47,7 @@ type ForceResult = {
 type RunArgs = {
 	aliases?: Record<string, string>;
 	cache?: boolean;
+	files?: string[];
 	force?: boolean;
 	mode?: string;
 	verbose?: boolean;
@@ -57,11 +59,13 @@ function parseCliArgs(argv: string[]) {
 		alias: {
 			c: 'cache',
 			f: 'force',
+			F: 'files',
 			m: 'mode',
 			v: 'verbose',
 			V: 'version',
 		},
 		boolean: ['force', 'cache', 'verbose', 'version'],
+		string: ['files', 'mode'],
 	}) as CliArgs;
 }
 
@@ -178,6 +182,19 @@ async function handleInteractiveClone() {
 	});
 }
 
+function normalizeFiles(files: string | string[] | boolean | undefined): string[] | undefined {
+	if (typeof files !== 'string' && !Array.isArray(files)) {
+		return undefined;
+	}
+
+	const list = Array.isArray(files) ? files : [files];
+	const result = list
+		.flatMap((file) => file.split(','))
+		.map((file) => file.trim())
+		.filter(Boolean);
+	return result.length > 0 ? result : undefined;
+}
+
 export async function main(argv: string[]) {
 	const args = parseCliArgs(argv);
 
@@ -214,7 +231,8 @@ export async function main(argv: string[]) {
 	}
 
 	const aliases = loadAliases();
-	run(resolveAlias(aliases, src) ?? src, dest, { ...args, aliases });
+	const files = normalizeFiles(args.files);
+	run(resolveAlias(aliases, src) ?? src, dest, { ...args, aliases, files });
 }
 
 /* eslint-enable security/detect-non-literal-fs-filename */

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
 import colors from 'yoctocolors';
@@ -11,6 +12,7 @@ import {
 	checkDirIsEmpty,
 	copyRepoSubdir,
 	getDirectives,
+	keepFiles,
 	removeFiles,
 } from '../operations/filesystem.js';
 import { cloneWithTar as cloneWithTarMode } from '../transports/tar/archive.js';
@@ -33,6 +35,7 @@ function cloneSuccessMessage(user: string, name: string, ref: string, dest: stri
 export class Degit {
 	aliases: Record<string, string>;
 	cache?: boolean;
+	files?: string[];
 	force?: boolean;
 	mode: ValidModes;
 	verbose?: boolean;
@@ -49,6 +52,7 @@ export class Degit {
 	constructor(src: string, opts: ConstructorOptions = {}) {
 		this.aliases = opts.aliases ?? {};
 		this.cache = opts.cache;
+		this.files = opts.files;
 		this.force = opts.force;
 		this.verbose = opts.verbose;
 		this.proxy = process.env.https_proxy;
@@ -94,6 +98,7 @@ export class Degit {
 	async clone(dest: string): Promise<void> {
 		checkDirIsEmpty(dest, this.force, this.info.bind(this), this.verboseInfo.bind(this));
 		await this.cloneToDestination(dest);
+		keepFiles(dest, this.files, this.warn.bind(this));
 		this.info({
 			code: 'SUCCESS',
 			dest,

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -13,6 +13,7 @@ export type ConstructorOptions = {
 	aliases?: Record<string, string>;
 	cache?: boolean;
 	fetch?: FetchFn;
+	files?: string[];
 	force?: boolean;
 	git?: GitClient;
 	mode?: 'tar' | 'git';
@@ -23,6 +24,7 @@ export type InfoCode =
 	| 'SUCCESS'
 	| 'FILE_DOES_NOT_EXIST'
 	| 'FILE_OUTSIDE_DEST'
+	| 'NO_FILES_MATCHED'
 	| 'REMOVED'
 	| 'DEST_NOT_EMPTY'
 	| 'DEST_IS_EMPTY'
@@ -64,6 +66,7 @@ export type Directive =
 	| {
 			action: 'clone';
 			cache?: boolean;
+			files?: string | string[];
 			src: string;
 			verbose?: boolean;
 	  }

--- a/src/operations/directives.ts
+++ b/src/operations/directives.ts
@@ -54,10 +54,17 @@ async function cloneDirective(
 		context.hasStashed = true;
 	}
 
+	const files = action.files
+		? Array.isArray(action.files)
+			? action.files
+			: [action.files]
+		: undefined;
+
 	const child = createChild(action.src, {
 		aliases: context.aliases,
 		cache: action.cache,
 		fetch: context.fetch,
+		files,
 		force: true,
 		git: await context.getGitClient(),
 		verbose: action.verbose,

--- a/src/operations/filesystem.ts
+++ b/src/operations/filesystem.ts
@@ -103,6 +103,95 @@ function removeFile(root: string, file: string, warn: Emit) {
 	return [file];
 }
 
+// eslint-disable-next-line max-lines-per-function
+export function keepFiles(dest: string, files: string[] | undefined, warn: Emit) {
+	if (!files || files.length === 0) {
+		return;
+	}
+
+	const root = path.resolve(dest);
+	const keepFileSet = new Set<string>();
+	const keepDirSet = new Set<string>();
+	let hasUserKeeps = false;
+
+	for (const file of files) {
+		const filePath = path.resolve(root, file);
+		const relativePath = path.relative(root, filePath);
+
+		if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+			warn({
+				code: 'FILE_OUTSIDE_DEST',
+				message: `action wants to keep ${colors.bold(file)} but it is outside the destination, skipping`,
+			});
+			continue;
+		}
+
+		if (!fs.existsSync(filePath)) {
+			warn({
+				code: 'FILE_DOES_NOT_EXIST',
+				message: `action wants to keep ${colors.bold(file)} but it does not exist`,
+			});
+			continue;
+		}
+
+		const stats = fs.lstatSync(filePath);
+		if (!stats.isSymbolicLink() && stats.isDirectory()) {
+			keepDirSet.add(filePath);
+		} else {
+			keepFileSet.add(filePath);
+		}
+		hasUserKeeps = true;
+	}
+
+	if (!hasUserKeeps) {
+		warn({
+			code: 'NO_FILES_MATCHED',
+			message: `no requested files were found, keeping the entire destination`,
+		});
+		return;
+	}
+
+	const directivesPath = path.resolve(root, degitConfigName);
+	try {
+		if (fs.lstatSync(directivesPath).isFile()) {
+			keepFileSet.add(directivesPath);
+		}
+	} catch {
+		// degit.json is missing or not accessible
+	}
+
+	function isKept(filePath: string): boolean {
+		if (keepFileSet.has(filePath)) {
+			return true;
+		}
+
+		for (const dir of keepDirSet) {
+			if (filePath === dir || filePath.startsWith(path.join(dir, ''))) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	prune(root);
+
+	function prune(dir: string) {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const fullPath = path.join(dir, entry.name);
+
+			if (entry.isDirectory() && !entry.isSymbolicLink()) {
+				prune(fullPath);
+				if (fs.readdirSync(fullPath).length === 0 && !isKept(fullPath)) {
+					fs.rmdirSync(fullPath);
+				}
+			} else if (!isKept(fullPath)) {
+				fs.unlinkSync(fullPath);
+			}
+		}
+	}
+}
+
 export function copyRepoSubdir(srcDir: string, dest: string, subdir: string) {
 	const normalized = subdir.split('/').filter(Boolean).join('/');
 	const source = path.join(srcDir, normalized);

--- a/test/unit/bin.test.ts
+++ b/test/unit/bin.test.ts
@@ -106,6 +106,10 @@ describe('degit bin', () => {
 		}
 	}
 
+	async function runMainWithFiles(argv: string[]) {
+		await main(['node', 'bin', 'a/b', 'dest', ...argv]);
+	}
+
 	async function captureMainStdout(args: string[]): Promise<string> {
 		const chunks: string[] = [];
 		const orig = process.stdout.write.bind(process.stdout);
@@ -293,6 +297,36 @@ describe('degit bin', () => {
 		} finally {
 			warnSpy.mockRestore();
 		}
+	});
+
+	it('forwards --files as a string array when argv passes a comma-separated list', async () => {
+		await runMainWithFiles(['--files', 'README.md,src/index.ts']);
+		assert.equal(mockDegit.mock.calls.length, 1);
+		assert.deepEqual(mockDegit.mock.calls[0][1].files, ['README.md', 'src/index.ts']);
+	});
+
+	it('forwards -F as a string array when the short flag is used with commas', async () => {
+		await runMainWithFiles(['-F', 'README.md,src/index.ts']);
+		assert.equal(mockDegit.mock.calls.length, 1);
+		assert.deepEqual(mockDegit.mock.calls[0][1].files, ['README.md', 'src/index.ts']);
+	});
+
+	it('forwards repeated -F flags as a single string array when argv repeats the flag', async () => {
+		await runMainWithFiles(['-F', 'README.md', '-F', 'src/index.ts']);
+		assert.equal(mockDegit.mock.calls.length, 1);
+		assert.deepEqual(mockDegit.mock.calls[0][1].files, ['README.md', 'src/index.ts']);
+	});
+
+	it('trims and drops empty entries when argv has extra commas and whitespace', async () => {
+		await runMainWithFiles(['--files', ' README.md,, src/index.ts ']);
+		assert.equal(mockDegit.mock.calls.length, 1);
+		assert.deepEqual(mockDegit.mock.calls[0][1].files, ['README.md', 'src/index.ts']);
+	});
+
+	it('ignores a bare --files flag when no value is provided', async () => {
+		await runMainWithFiles(['--files']);
+		assert.equal(mockDegit.mock.calls.length, 1);
+		assert.equal(mockDegit.mock.calls[0][1].files, undefined);
 	});
 
 	it('exits with status 1 when the clone promise rejects', async () => {

--- a/test/unit/directives.test.ts
+++ b/test/unit/directives.test.ts
@@ -31,8 +31,8 @@ afterEach(() => {
 	delete process.env.PROJECT_NAME;
 });
 
-/* eslint-disable max-lines-per-function */
-describe('search_replace', () => {
+/* eslint-disable max-lines, max-lines-per-function */
+describe('directives', () => {
 	it('replaces every match in targeted files when the env var exists', async () => {
 		const root = makeTempWorkspace('search-replace-');
 		const dest = path.join(root, 'dest');
@@ -179,5 +179,43 @@ describe('search_replace', () => {
 			fs.rmSync(root, { force: true, recursive: true });
 		}
 	});
+
+	async function runCloneDirective(files: string | string[]): Promise<string[] | undefined> {
+		const root = makeTempWorkspace('clone-');
+		const dest = path.join(root, 'dest');
+		const { context, createChild } = makeDispatcher();
+
+		try {
+			fs.mkdirSync(dest, { recursive: true });
+
+			await applyDirectives(
+				context as never,
+				[
+					{
+						action: 'clone',
+						src: 'user/another-repo',
+						files,
+					},
+				],
+				root,
+				dest,
+				createChild,
+			);
+
+			return createChild.mock.calls[0][1].files;
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	}
+
+	it('passes files to the child clone when the clone directive lists files', async () => {
+		const files = await runCloneDirective(['README.md', 'src/index.ts']);
+		assert.deepEqual(files, ['README.md', 'src/index.ts']);
+	});
+
+	it('passes a single files value as an array when the clone directive uses a string', async () => {
+		const files = await runCloneDirective('README.md');
+		assert.deepEqual(files, ['README.md']);
+	});
 });
-/* eslint-enable max-lines-per-function */
+/* eslint-enable max-lines, max-lines-per-function */

--- a/test/unit/filesystem.test.ts
+++ b/test/unit/filesystem.test.ts
@@ -1,16 +1,24 @@
+/* eslint-disable max-lines */
 import assert from 'node:assert';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'vitest';
-import { getDirectives } from '../../src/operations/filesystem.js';
+import { getDirectives, keepFiles } from '../../src/operations/filesystem.js';
+import type { EventInfo } from '../../src/domain/types.js';
 
 function makeTempWorkspace() {
 	return fs.mkdtempSync(path.join(os.tmpdir(), 'degit-filesystem-'));
 }
 
+function runKeepFiles(root: string, files: string[] | undefined) {
+	const warnings: EventInfo[] = [];
+	keepFiles(root, files, (info) => warnings.push(info));
+	return warnings;
+}
+
 /* eslint-disable max-lines-per-function */
-describe('getDirectives', () => {
+describe('filesystem', () => {
 	it('loads and removes directives when degit.json is a regular JSON file', () => {
 		const root = makeTempWorkspace();
 		const directives = [{ action: 'remove', files: 'LICENSE' }];
@@ -94,6 +102,193 @@ describe('getDirectives', () => {
 
 			assert.equal(getDirectives(root), false);
 			assert.equal(fs.readFileSync(directivesPath, 'utf8'), '{}');
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	it('keeps listed files when files contains file paths', () => {
+		const root = makeTempWorkspace();
+
+		try {
+			fs.writeFileSync(path.join(root, 'README.md'), 'readme');
+			fs.writeFileSync(path.join(root, 'package.json'), '{}');
+
+			const warnings = runKeepFiles(root, ['README.md']);
+
+			assert.equal(fs.existsSync(path.join(root, 'README.md')), true);
+			assert.equal(fs.existsSync(path.join(root, 'package.json')), false);
+			assert.deepEqual(warnings, []);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	it('keeps a listed directory and its descendants when files contains a directory path', () => {
+		const root = makeTempWorkspace();
+
+		try {
+			fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+			fs.writeFileSync(path.join(root, 'src', 'index.ts'), 'index');
+			fs.writeFileSync(path.join(root, 'README.md'), 'readme');
+
+			const warnings = runKeepFiles(root, ['src']);
+
+			assert.equal(fs.existsSync(path.join(root, 'src', 'index.ts')), true);
+			assert.equal(fs.existsSync(path.join(root, 'README.md')), false);
+			assert.deepEqual(warnings, []);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	it('warns and skips a path that escapes the destination when files contains a path outside the destination', () => {
+		const workspace = makeTempWorkspace();
+		const root = path.join(workspace, 'dest');
+
+		try {
+			fs.mkdirSync(root, { recursive: true });
+			fs.writeFileSync(path.join(root, 'README.md'), 'readme');
+
+			const warnings = runKeepFiles(root, ['../outside']);
+
+			assert.equal(fs.existsSync(path.join(root, 'README.md')), true);
+			assert.equal(warnings.length, 2);
+			assert.equal(warnings[0].code, 'FILE_OUTSIDE_DEST');
+			assert.match(warnings[0].message, /\.\.\/outside/u);
+			assert.equal(warnings[1].code, 'NO_FILES_MATCHED');
+		} finally {
+			fs.rmSync(workspace, { force: true, recursive: true });
+		}
+	});
+
+	it('warns and skips a missing file when files contains a path that does not exist', () => {
+		const root = makeTempWorkspace();
+
+		try {
+			fs.writeFileSync(path.join(root, 'README.md'), 'readme');
+
+			const warnings = runKeepFiles(root, ['missing.txt']);
+
+			assert.equal(fs.existsSync(path.join(root, 'README.md')), true);
+			assert.equal(warnings.length, 2);
+			assert.equal(warnings[0].code, 'FILE_DOES_NOT_EXIST');
+			assert.match(warnings[0].message, /missing\.txt/u);
+			assert.equal(warnings[1].code, 'NO_FILES_MATCHED');
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	it('preserves nested files inside a kept directory when a directory is listed', () => {
+		const root = makeTempWorkspace();
+
+		try {
+			fs.mkdirSync(path.join(root, 'src', 'nested'), { recursive: true });
+			fs.writeFileSync(path.join(root, 'src', 'nested', 'file.ts'), 'nested');
+			fs.writeFileSync(path.join(root, 'README.md'), 'readme');
+
+			const warnings = runKeepFiles(root, ['src']);
+
+			assert.equal(fs.existsSync(path.join(root, 'src', 'nested', 'file.ts')), true);
+			assert.equal(fs.existsSync(path.join(root, 'README.md')), false);
+			assert.deepEqual(warnings, []);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	it('preserves parent directories of kept files while deleting sibling files when a file inside the directory is kept', () => {
+		const root = makeTempWorkspace();
+
+		try {
+			fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+			fs.writeFileSync(path.join(root, 'src', 'keep.ts'), 'keep');
+			fs.writeFileSync(path.join(root, 'src', 'drop.ts'), 'drop');
+			fs.writeFileSync(path.join(root, 'README.md'), 'readme');
+
+			const warnings = runKeepFiles(root, ['src/keep.ts']);
+
+			assert.equal(fs.existsSync(path.join(root, 'src', 'keep.ts')), true);
+			assert.equal(fs.existsSync(path.join(root, 'src', 'drop.ts')), false);
+			assert.equal(fs.existsSync(path.join(root, 'src')), true);
+			assert.equal(fs.existsSync(path.join(root, 'README.md')), false);
+			assert.deepEqual(warnings, []);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	it('preserves a regular top-level degit.json when files is provided', () => {
+		const root = makeTempWorkspace();
+
+		try {
+			fs.writeFileSync(path.join(root, 'README.md'), 'readme');
+			fs.writeFileSync(path.join(root, 'package.json'), '{}');
+			fs.writeFileSync(path.join(root, 'degit.json'), 'not valid');
+
+			const warnings = runKeepFiles(root, ['README.md']);
+
+			assert.equal(fs.existsSync(path.join(root, 'README.md')), true);
+			assert.equal(fs.existsSync(path.join(root, 'degit.json')), true);
+			assert.equal(fs.existsSync(path.join(root, 'package.json')), false);
+			assert.deepEqual(warnings, []);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	it('keeps the whole destination and warns when no requested files resolve', () => {
+		const root = makeTempWorkspace();
+
+		try {
+			fs.writeFileSync(path.join(root, 'README.md'), 'readme');
+			fs.writeFileSync(path.join(root, 'package.json'), '{}');
+
+			const warnings = runKeepFiles(root, ['missing.txt']);
+
+			assert.equal(fs.existsSync(path.join(root, 'README.md')), true);
+			assert.equal(fs.existsSync(path.join(root, 'package.json')), true);
+			assert.equal(warnings.length, 2);
+			assert.equal(warnings[0].code, 'FILE_DOES_NOT_EXIST');
+			assert.equal(warnings[1].code, 'NO_FILES_MATCHED');
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	it('keeps listed symlinks without following them when files contains symlinks', () => {
+		const root = makeTempWorkspace();
+
+		try {
+			fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+			fs.writeFileSync(path.join(root, 'src', 'file.ts'), 'file');
+			fs.writeFileSync(path.join(root, 'keep.txt'), 'keep');
+			fs.symlinkSync('src', path.join(root, 'dir-link'));
+			fs.symlinkSync('keep.txt', path.join(root, 'file-link'));
+
+			const warnings = runKeepFiles(root, ['dir-link', 'file-link']);
+
+			assert.equal(fs.lstatSync(path.join(root, 'dir-link')).isSymbolicLink(), true);
+			assert.equal(fs.lstatSync(path.join(root, 'file-link')).isSymbolicLink(), true);
+			assert.equal(fs.existsSync(path.join(root, 'src')), false);
+			assert.equal(fs.existsSync(path.join(root, 'keep.txt')), false);
+			assert.deepEqual(warnings, []);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	it('leaves the destination unchanged when files is undefined', () => {
+		const root = makeTempWorkspace();
+
+		try {
+			fs.writeFileSync(path.join(root, 'README.md'), 'readme');
+
+			const warnings = runKeepFiles(root, undefined);
+
+			assert.equal(fs.existsSync(path.join(root, 'README.md')), true);
+			assert.deepEqual(warnings, []);
 		} finally {
 			fs.rmSync(root, { force: true, recursive: true });
 		}

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -1,8 +1,10 @@
+/* eslint-disable max-lines */
 import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 import degit from '../../src/index.js';
 import { generateGitlabRepoCandidates, parse } from '../../src/domain/repo.js';
+import { Degit } from '../../src/core/orchestrator.js';
 import { providerCases } from './index-support.js';
 
 const { suiteCache, suiteTmp } = vi.hoisted(() => ({
@@ -293,6 +295,64 @@ describe('degit index', () => {
 
 		assert.equal(candidates.length, 1);
 		assert.equal(candidates[0], repo);
+	});
+
+	async function withCloneFiles(
+		files: string[],
+		setup: (target: string) => void,
+		assertions: (dest: string) => void,
+	) {
+		fs.mkdirSync(suiteTmp, { recursive: true });
+		const dest = fs.mkdtempSync(path.join(suiteTmp, 'files-'));
+		const stub = vi
+			.spyOn(Degit.prototype as any, 'cloneToDestination')
+			.mockImplementation((target: string) => {
+				setup(target);
+				return Promise.resolve();
+			});
+
+		try {
+			await degit('Rich-Harris/degit-test-repo', { force: true, files }).clone(dest);
+			assertions(dest);
+		} finally {
+			stub.mockRestore();
+			fs.rmSync(suiteTmp, { force: true, recursive: true });
+		}
+	}
+
+	it('keeps only the requested files and degit.json when the clone finishes', async () => {
+		await withCloneFiles(
+			['README.md'],
+			(target) => {
+				fs.writeFileSync(path.join(target, 'README.md'), 'readme');
+				fs.writeFileSync(path.join(target, 'package.json'), '{}');
+				fs.writeFileSync(path.join(target, 'degit.json'), 'not an array');
+			},
+			(dest) => {
+				assert.equal(fs.existsSync(path.join(dest, 'README.md')), true);
+				assert.equal(fs.existsSync(path.join(dest, 'package.json')), false);
+				assert.equal(fs.existsSync(path.join(dest, 'degit.json')), true);
+			},
+		);
+	});
+
+	it('applies remove directives to kept files when files includes the removed path', async () => {
+		await withCloneFiles(
+			['README.md', 'package.json'],
+			(target) => {
+				fs.writeFileSync(path.join(target, 'README.md'), 'readme');
+				fs.writeFileSync(path.join(target, 'package.json'), '{}');
+				fs.writeFileSync(
+					path.join(target, 'degit.json'),
+					JSON.stringify([{ action: 'remove', files: 'package.json' }]),
+				);
+			},
+			(dest) => {
+				assert.equal(fs.existsSync(path.join(dest, 'README.md')), true);
+				assert.equal(fs.existsSync(path.join(dest, 'package.json')), false);
+				assert.equal(fs.existsSync(path.join(dest, 'degit.json')), false);
+			},
+		);
 	});
 });
 /* eslint-enable max-lines-per-function */


### PR DESCRIPTION
## Summary

**What**

Add a `files` option to degit so users can clone only specific files or directories from a repository.

**Why**

Resolves [GitHub issue #129](https://github.com/Rich-Harris/degit/issues/129): users want to pull a subset of files without downloading the whole repo.

## Linked issues

Closes #129

## Changes

- `src/domain/types.ts`: add `files?: string[]` to `ConstructorOptions` and `NO_FILES_MATCHED` to `InfoCode`; add `files` to the `clone` directive type.
- `src/bin.ts`: add `--files` / `-F` CLI flags with comma-separated and repeated-flag support.
- `src/operations/filesystem.ts`: add `keepFiles()` helper that prunes the destination after extraction, preserving requested files/directories, parent directories, and a regular top-level `degit.json`.
- `src/core/orchestrator.ts`: store `opts.files` and call `keepFiles()` right after `cloneToDestination()`.
- `src/operations/directives.ts`: pass `files` to child clones created by `degit.json` `clone` actions.
- `assets/help.md`, `README.md`, `schemas/degit.schema.json`, `skills/degit/SKILL.md`, `docs/CHANGELOG.md`: document the new option.
- Tests added in `test/unit/filesystem.test.ts`, `test/unit/bin.test.ts`, `test/unit/directives.test.ts`, and `test/unit/index.test.ts`.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`) — 173 tests passed
- [x] Manual / CLI check if user-facing behavior changed — `node dist/bin.js Rich-Harris/degit-test-repo .tmp/files-test --files file.txt -f` left only `file.txt`
- [x] CI passes — `bun run typecheck`, `bun run lint:ci`, `bun run format:ci`, `bun run duplicates:ci`, `bun run knip:ci`, and `bun run build` all pass locally

## Review notes

**Breaking changes** (or none)

None. The option is optional and defaults to existing behavior.

**Risks / rollout** (or none)

- `keepFiles()` resolves requested paths under the destination and rejects paths that escape; it emits warnings for missing or out-of-bound paths and falls back to keeping the entire destination when no requested paths resolve.
- Symlinks are treated as leaf entries and are never followed during pruning.

**Focus areas for reviewers** (optional)

- `keepFiles()` post-clone pruning logic and edge cases (missing files, outside paths, symlinks, empty/malformed `degit.json`).
- CLI `normalizeFiles()` handling of bare `--files`, `--no-files`, repeated `-F`, comma-separated values, and whitespace.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
