### PR TITLE
refactor: apply ponytail audit simplifications

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
   },
   "overrides": {
     "brace-expansion": "1.1.16",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "postcss": "8.5.23",
     "vite": "8.0.16",
   },
@@ -668,7 +668,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "node-sarif-builder": ["node-sarif-builder@3.4.0", "", { "dependencies": { "@types/sarif": "^2.1.7", "fs-extra": "^11.1.1" } }, "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,5 @@
 [install]
-minimumReleaseAge = 1209600
+minimumReleaseAge = 604800
 exact = true
 minimumReleaseAgeExcludes = ["tar", "postcss"]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # degit changelog
 
+## 3.7.1
+
+- Reject `remove` and `keep` directives that resolve to the destination root, preventing a `degit.json` action from deleting the whole clone.
+- Fix `--help` crash on Node 20.10 caused by `import.meta.dirname` being undefined before Node 20.11.
+- Fix interactive cache prompt crash on corrupt `access.json`.
+
 ## 3.7.0
 
 - Redownload cached tar archives when extraction fails with any tar/zlib error, not only `TAR_BAD_ARCHIVE` ([#41](https://github.com/Rich-Harris/degit/issues/41)).

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 	},
 	"overrides": {
 		"brace-expansion": "1.1.16",
-		"nanoid": "3.3.17",
+		"nanoid": "3.3.18",
 		"postcss": "8.5.23",
 		"vite": "8.0.16"
 	},

--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -1,17 +1,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import colors from 'yoctocolors';
-import { base, mkdirp } from './shared/utils.js';
+import { base, mkdirp, tryReadJson } from './shared/utils.js';
 
 export const aliasesFile = path.join(base, 'aliases.json');
 
 /* eslint-disable security/detect-non-literal-fs-filename */
 export function loadAliases(): Record<string, string> {
-	try {
-		return JSON.parse(fs.readFileSync(aliasesFile, 'utf8')) as Record<string, string>;
-	} catch {
-		return {};
-	}
+	return (tryReadJson(aliasesFile) as Record<string, string>) ?? {};
 }
 
 function writeAliases(aliases: Record<string, string>) {
@@ -21,7 +17,8 @@ function writeAliases(aliases: Record<string, string>) {
 /* eslint-enable security/detect-non-literal-fs-filename */
 
 export function resolveAlias(aliases: Record<string, string>, name: string): string | undefined {
-	return Object.entries(aliases).find(([key]) => key === name)?.[1];
+	// oxlint-disable-next-line security/detect-object-injection
+	return Object.hasOwn(aliases, name) ? aliases[name] : undefined;
 }
 
 export function saveAlias(name: string, repo: string) {
@@ -37,12 +34,13 @@ export function removeAlias(name: string): boolean {
 		return false;
 	}
 
-	const updated = Object.fromEntries(Object.entries(aliases).filter(([key]) => key !== name));
+	// oxlint-disable-next-line security/detect-object-injection
+	delete aliases[name];
 
-	if (Object.keys(updated).length === 0) {
+	if (Object.keys(aliases).length === 0) {
 		fs.rmSync(aliasesFile, { force: true });
 	} else {
-		writeAliases(updated);
+		writeAliases(aliases);
 	}
 
 	return true;

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import colors from 'yoctocolors';
 import enquirer from 'enquirer';
 import fuzzysearch from 'fuzzysearch';
@@ -13,9 +12,7 @@ import {
 	loadAliases,
 	resolveAlias,
 } from './aliases.js';
-import { base, tryRequire } from './shared/utils.js';
-
-const dirname = import.meta.dirname;
+import { base, DegitError, tryReadJson } from './shared/utils.js';
 
 type Choice = {
 	message: string;
@@ -71,7 +68,7 @@ function parseCliArgs(argv: string[]) {
 
 function displayHelp() {
 	const help = fs
-		.readFileSync(path.join(dirname, '..', 'assets', 'help.md'), 'utf8')
+		.readFileSync(new URL('../assets/help.md', import.meta.url), 'utf8')
 		.replaceAll(/^(\s*)#+ (.+)/gmu, (_match, indent, title) => indent + colors.bold(title))
 		.replaceAll(/_([^_]+)_/gu, (_match, value) => colors.underline(value))
 		.replaceAll(/`([^`]+)`/gu, (_match, value) => colors.cyan(value));
@@ -80,18 +77,18 @@ function displayHelp() {
 }
 
 function getVersion() {
-	for (const relativePath of ['../package.json', '../../package.json']) {
-		try {
-			const url = new URL(relativePath, import.meta.url);
-			const pkg = JSON.parse(fs.readFileSync(url, 'utf8')) as { version: string };
-
-			return pkg.version;
-		} catch {
-			// try next path
-		}
+	try {
+		return (
+			JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
+				version: string;
+			}
+		).version;
+	} catch (error) {
+		throw new DegitError('Could not find package.json', {
+			code: 'COULD_NOT_FIND_PACKAGE',
+			original: error,
+		});
 	}
-
-	throw new Error('Could not find package.json');
 }
 
 function getInteractiveChoices(): Choice[] {
@@ -102,8 +99,7 @@ function getInteractiveChoices(): Choice[] {
 	glob('**/access.json', { cwd: base }).forEach((file) => {
 		const normalizedFile = file.replaceAll('\\', '/');
 		const [host, user, repo] = normalizedFile.split('/');
-		const json = fs.readFileSync(`${base}/${file}`, 'utf8');
-		const logs = JSON.parse(json) as Record<string, string | number>;
+		const logs = (tryReadJson(`${base}/${file}`) as Record<string, string | number>) ?? {};
 
 		Object.entries(logs).forEach(([ref, timestamp]) => {
 			const id = `${host}:${user}/${repo}#${ref}`;
@@ -114,7 +110,7 @@ function getInteractiveChoices(): Choice[] {
 	const getChoices = (file: string): Choice[] => {
 		const normalizedFile = file.replaceAll('\\', '/');
 		const [host, user, repo] = normalizedFile.split('/');
-		const entries = Object.entries(tryRequire(`${base}/${file}`) || {});
+		const entries = Object.entries(tryReadJson(`${base}/${file}`) ?? {});
 
 		return entries.map(([ref, hash]) => ({
 			message: `${host}:${user}/${repo}#${ref}`,

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,12 +1,11 @@
 /* eslint-disable max-lines */
+/* oxlint-disable import/max-dependencies */
+import { EventEmitter } from 'node:events';
 import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
 import colors from 'yoctocolors';
+import { resolveAlias } from '../aliases.js';
 import { generateGitlabRepoCandidates, parse, type Repo } from '../domain/repo.js';
-
-function resolveAlias(aliases: Record<string, string>, name: string): string | undefined {
-	return Object.entries(aliases).find(([key]) => key === name)?.[1];
-}
 import { applyDirectives } from '../operations/directives.js';
 import {
 	checkDirIsEmpty,
@@ -22,17 +21,16 @@ import {
 	type Directive,
 	type EventInfo,
 	type FetchFn,
+	type GitClient,
 	type RemoveDirective,
 	type ValidModes,
 } from '../domain/types.js';
-import type { GitClient } from '../domain/types.js';
 import { base, DegitError, fetch } from '../shared/utils.js';
-type InfoListener = (info: EventInfo) => void;
 function cloneSuccessMessage(user: string, name: string, ref: string, dest: string) {
 	const destination = dest === '.' ? '' : ` to ${dest}`;
 	return `cloned ${colors.bold(`${user}/${name}`)}#${colors.bold(ref)}${destination}`;
 }
-export class Degit {
+export class Degit extends EventEmitter {
 	aliases: Record<string, string>;
 	cache?: boolean;
 	files?: string[];
@@ -46,10 +44,9 @@ export class Degit {
 	gitClientPromise?: Promise<GitClient>;
 	hasStashed: boolean;
 	private src: string;
-	private infoListeners: InfoListener[];
-	private warnListeners: InfoListener[];
 
 	constructor(src: string, opts: ConstructorOptions = {}) {
+		super();
 		this.aliases = opts.aliases ?? {};
 		this.cache = opts.cache;
 		this.files = opts.files;
@@ -63,20 +60,10 @@ export class Degit {
 		this.fetch = opts.fetch || fetch;
 		this.git = opts.git;
 		this.hasStashed = false;
-		this.infoListeners = [];
-		this.warnListeners = [];
 
 		if (opts.mode && !validModes.has(opts.mode)) {
 			throw new Error(`Valid modes are ${[...validModes].join(', ')}`);
 		}
-	}
-	on(eventName: 'info' | 'warn', listener: InfoListener) {
-		if (eventName === 'info') {
-			this.infoListeners.push(listener);
-		} else {
-			this.warnListeners.push(listener);
-		}
-		return this;
 	}
 	getGitClient(): Promise<GitClient> {
 		if (this.git) {
@@ -111,10 +98,10 @@ export class Degit {
 		removeFiles(dest, action, this.info.bind(this), this.warn.bind(this));
 	}
 	info(info: EventInfo) {
-		this.emitEvent('info', info);
+		this.emit('info', info);
 	}
 	warn(info: EventInfo) {
-		this.emitEvent('warn', info);
+		this.emit('warn', info);
 	}
 	verboseInfo(info: EventInfo) {
 		if (this.verbose) {
@@ -210,12 +197,6 @@ export class Degit {
 		const code = (error as { code?: string }).code;
 		return code === 'COULD_NOT_DOWNLOAD' && !this.cache;
 	}
-	private emitEvent(eventName: 'info' | 'warn', info: EventInfo) {
-		const listeners = eventName === 'info' ? this.infoListeners : this.warnListeners;
-		for (const listener of listeners) {
-			listener(info);
-		}
-	}
 	private getRepoDir() {
 		return path.join(base, this.repo.site, this.repo.user, this.repo.name);
 	}
@@ -302,4 +283,8 @@ export class Degit {
 			(src, opts) => new Degit(src, opts),
 		);
 	}
+}
+
+export interface Degit {
+	on(eventName: 'info' | 'warn', listener: (info: EventInfo) => void): this;
 }

--- a/src/domain/repo.ts
+++ b/src/domain/repo.ts
@@ -1,10 +1,12 @@
 import { DegitError } from '../shared/utils.js';
 
+export type GitProvider = 'github' | 'gitlab' | 'bitbucket' | 'git.sr.ht';
+
 export type Repo = {
 	mode: 'tar' | 'git';
 	name: string;
 	ref: string;
-	site: string;
+	site: GitProvider;
 	transport: 'https' | 'ssh';
 	ssh: string;
 	subdir?: string;
@@ -14,14 +16,12 @@ export type Repo = {
 
 type ArchiveContext = Pick<Repo, 'url' | 'name'>;
 
-export type GitProvider = 'github' | 'gitlab' | 'bitbucket' | 'git.sr.ht';
-
-type Provider = {
-	domain: string;
-	archiveUrl(repo: ArchiveContext, hash: string): string;
-};
-
-const supported = new Set(['github', 'gitlab', 'bitbucket', 'git.sr.ht']);
+const providerDomains = new Map<GitProvider, string>([
+	['github', 'github.com'],
+	['gitlab', 'gitlab.com'],
+	['bitbucket', 'bitbucket.org'],
+	['git.sr.ht', 'git.sr.ht'],
+]);
 
 export const providerArchiveTemplates: Record<
 	GitProvider,
@@ -33,31 +33,8 @@ export const providerArchiveTemplates: Record<
 	'git.sr.ht': (repo, hash) => `${repo.url}/archive/${hash}.tar.gz`,
 };
 
-export function getProvider(site: string): Provider | undefined {
-	switch (site) {
-		case 'github':
-			return {
-				domain: 'github.com',
-				archiveUrl: providerArchiveTemplates.github,
-			};
-		case 'gitlab':
-			return {
-				domain: 'gitlab.com',
-				archiveUrl: providerArchiveTemplates.gitlab,
-			};
-		case 'bitbucket':
-			return {
-				domain: 'bitbucket.org',
-				archiveUrl: providerArchiveTemplates.bitbucket,
-			};
-		case 'git.sr.ht':
-			return {
-				domain: 'git.sr.ht',
-				archiveUrl: providerArchiveTemplates['git.sr.ht'],
-			};
-		default:
-			return undefined;
-	}
+function isGitProvider(site: string): site is GitProvider {
+	return Object.hasOwn(providerArchiveTemplates, site);
 }
 
 type ResolvedSource = {
@@ -168,14 +145,7 @@ export function parse(src: string): Repo {
 		decodedSrc,
 	);
 
-	if (!supported.has(site)) {
-		throw new DegitError(`degit supports GitHub, GitLab, Sourcehut and BitBucket`, {
-			code: 'UNSUPPORTED_HOST',
-		});
-	}
-
-	const provider = getProvider(site);
-	if (!provider) {
+	if (!isGitProvider(site)) {
 		throw new DegitError(`degit supports GitHub, GitLab, Sourcehut and BitBucket`, {
 			code: 'UNSUPPORTED_HOST',
 		});
@@ -193,7 +163,7 @@ export function parse(src: string): Repo {
 	let ref = refValue;
 	let subdirParts = rest;
 	if (isWebUrl) {
-		const parsed = parseWebPath(site as GitProvider, rest);
+		const parsed = parseWebPath(site, rest);
 		if (parsed) {
 			if (refValue === 'HEAD') {
 				ref = parsed.ref;
@@ -204,7 +174,7 @@ export function parse(src: string): Repo {
 
 	const subdir = subdirParts.length > 0 ? `/${subdirParts.join('/')}` : undefined;
 
-	const domain = customDomain ?? provider.domain;
+	const domain = customDomain ?? providerDomains.get(site)!;
 	const url = `https://${domain}/${user}/${name}`;
 	const ssh = `ssh://git@${domain}/${user}/${name}`;
 

--- a/src/operations/directives.ts
+++ b/src/operations/directives.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import colors from 'yoctocolors';
-import { stashFiles, unstashFiles } from '../shared/utils.js';
+import { safeResolve, stashFiles, unstashFiles } from '../shared/utils.js';
 import type { GitClient } from '../domain/types.js';
 import type {
 	CloneDirective,
@@ -107,11 +107,10 @@ export async function applyDirectives(
 	dest: string,
 	createChild: (src: string, opts: ConstructorOptions) => ChildDegit,
 ) {
-	await directives.reduce(
-		(previous, directive) =>
-			previous.then(() => runDirective(context, directive, dir, dest, createChild)),
-		Promise.resolve(),
-	);
+	for (const directive of directives) {
+		// oxlint-disable-next-line eslint/no-await-in-loop
+		await runDirective(context, directive, dir, dest, createChild);
+	}
 
 	if (context.hasStashed) {
 		unstashFiles(dir, dest);
@@ -155,10 +154,8 @@ function replaceFile(
 	replacement: string,
 	warn: (info: EventInfo) => void,
 ) {
-	const filePath = path.resolve(root, file);
-	const relativePath = path.relative(root, filePath);
-
-	if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+	const filePath = safeResolve(root, file);
+	if (!filePath) {
 		warn({
 			message: `action wants to search_replace ${colors.bold(file)} but it is outside the destination, skipping`,
 		});

--- a/src/operations/filesystem.ts
+++ b/src/operations/filesystem.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import colors from 'yoctocolors';
-import { DegitError, degitConfigName } from '../shared/utils.js';
+import { DegitError, degitConfigName, safeResolve, tryReadJson } from '../shared/utils.js';
 import type { Directive, EventInfo, RemoveDirective } from '../domain/types.js';
 
 type Emit = (info: EventInfo) => void;
@@ -15,7 +15,7 @@ export function getDirectives(dest: string): Directive[] | false {
 			return false;
 		}
 
-		const directives = JSON.parse(fs.readFileSync(directivesPath, 'utf8'));
+		const directives = tryReadJson(directivesPath);
 		if (!Array.isArray(directives)) {
 			return false;
 		}
@@ -75,10 +75,8 @@ export function removeFiles(dest: string, action: RemoveDirective, info: Emit, w
 }
 
 function removeFile(root: string, file: string, warn: Emit) {
-	const filePath = path.resolve(root, file);
-	const relativePath = path.relative(root, filePath);
-
-	if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+	const filePath = safeResolve(root, file);
+	if (!filePath) {
 		warn({
 			code: 'FILE_OUTSIDE_DEST',
 			message: `action wants to remove ${colors.bold(file)} but it is outside the destination, skipping`,
@@ -94,13 +92,9 @@ function removeFile(root: string, file: string, warn: Emit) {
 		return [];
 	}
 
-	if (fs.lstatSync(filePath).isDirectory()) {
-		fs.rmSync(filePath, { force: true, recursive: true });
-		return [`${file}/`];
-	}
-
-	fs.unlinkSync(filePath);
-	return [file];
+	const isDir = fs.lstatSync(filePath).isDirectory();
+	fs.rmSync(filePath, { force: true, recursive: true });
+	return isDir ? [`${file}/`] : [file];
 }
 
 // eslint-disable-next-line max-lines-per-function
@@ -112,13 +106,10 @@ export function keepFiles(dest: string, files: string[] | undefined, warn: Emit)
 	const root = path.resolve(dest);
 	const keepFileSet = new Set<string>();
 	const keepDirSet = new Set<string>();
-	let hasUserKeeps = false;
 
 	for (const file of files) {
-		const filePath = path.resolve(root, file);
-		const relativePath = path.relative(root, filePath);
-
-		if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+		const filePath = safeResolve(root, file);
+		if (!filePath) {
 			warn({
 				code: 'FILE_OUTSIDE_DEST',
 				message: `action wants to keep ${colors.bold(file)} but it is outside the destination, skipping`,
@@ -140,10 +131,9 @@ export function keepFiles(dest: string, files: string[] | undefined, warn: Emit)
 		} else {
 			keepFileSet.add(filePath);
 		}
-		hasUserKeeps = true;
 	}
 
-	if (!hasUserKeeps) {
+	if (keepFileSet.size === 0 && keepDirSet.size === 0) {
 		warn({
 			code: 'NO_FILES_MATCHED',
 			message: `no requested files were found, keeping the entire destination`,
@@ -160,13 +150,15 @@ export function keepFiles(dest: string, files: string[] | undefined, warn: Emit)
 		// degit.json is missing or not accessible
 	}
 
+	const keepDirInfo = [...keepDirSet].map((dir) => ({ dir, prefix: path.join(dir, path.sep) }));
+
 	function isKept(filePath: string): boolean {
 		if (keepFileSet.has(filePath)) {
 			return true;
 		}
 
-		for (const dir of keepDirSet) {
-			if (filePath === dir || filePath.startsWith(path.join(dir, ''))) {
+		for (const { dir, prefix } of keepDirInfo) {
+			if (filePath === dir || filePath.startsWith(prefix)) {
 				return true;
 			}
 		}

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -3,10 +3,8 @@ import path from 'node:path';
 import os from 'node:os';
 import https from 'node:https';
 import * as URL from 'node:url';
-import { createRequire } from 'node:module';
 import Agent from 'https-proxy-agent';
 
-const require = createRequire(import.meta.url);
 const tmpDirName = 'tmp';
 const degitConfigName = 'degit.json';
 
@@ -25,29 +23,28 @@ export class DegitError extends Error {
 	}
 }
 
-export function tryRequire(file: string) {
+export function safeResolve(root: string, file: string): string | undefined {
+	const filePath = path.resolve(root, file);
+	const relativePath = path.relative(root, filePath);
+
+	if (relativePath === '' || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+		return undefined;
+	}
+
+	return filePath;
+}
+
+/* eslint-disable security/detect-non-literal-fs-filename */
+export function tryReadJson(file: string) {
 	try {
-		// oxlint-disable-next-line security/detect-non-literal-require
-		return require(file);
+		return JSON.parse(fs.readFileSync(file, 'utf8'));
 	} catch {
 		return null;
 	}
 }
 
-/* eslint-disable security/detect-non-literal-fs-filename */
 export function mkdirp(dir: string): void {
-	const parent = path.dirname(dir);
-	if (parent === dir) {
-		return;
-	}
-
-	mkdirp(parent);
-
-	try {
-		fs.mkdirSync(dir);
-	} catch (error) {
-		if (error.code !== 'EEXIST') throw error;
-	}
+	fs.mkdirSync(dir, { recursive: true });
 }
 
 export function fetch(url: string, dest: string, proxy?: string): Promise<void> {

--- a/src/transports/git/client.ts
+++ b/src/transports/git/client.ts
@@ -174,54 +174,47 @@ async function cloneWithIsomorphicGit(
 	fs.rmSync(path.join(dest, '.git'), { force: true, recursive: true });
 }
 
-export function createGitClient(): GitClient {
-	return {
-		async fetchRefs(repo) {
-			try {
-				return repo.transport === 'ssh'
-					? await fetchRefsWithGitCli(repo)
-					: await fetchRefsWithIsomorphicGit(repo);
-			} catch (error) {
-				if (repo.transport === 'ssh' && isMissingGitBinaryError(error)) {
-					throw createMissingGitError(repo, error);
-				}
+function wrapGitError(
+	repo: Repo,
+	error: unknown,
+	transport: 'https' | 'ssh',
+	action: 'fetch' | 'clone',
+): never {
+	if (transport === 'ssh' && isMissingGitBinaryError(error)) {
+		throw createMissingGitError(repo, error);
+	}
 
-				if (repo.transport === 'ssh' && isMissingSshKeyError(error)) {
-					throw createSshError(repo, error);
-				}
+	if (transport === 'ssh' && isMissingSshKeyError(error)) {
+		throw createSshError(repo, error);
+	}
 
-				throw new DegitError(`could not fetch remote ${repo.url}`, {
-					code: 'COULD_NOT_FETCH',
-					original: error,
-					url: repo.url,
-				});
-			}
-		},
-
-		async clone(repo, dest, ref, transport = repo.transport) {
-			try {
-				if (transport === 'ssh') {
-					await cloneWithGitCli(repo, dest, ref, transport);
-				} else {
-					await cloneWithIsomorphicGit(repo, dest, ref, transport);
-				}
-			} catch (error) {
-				if (transport === 'ssh' && isMissingGitBinaryError(error)) {
-					throw createMissingGitError(repo, error);
-				}
-
-				if (transport === 'ssh' && isMissingSshKeyError(error)) {
-					throw createSshError(repo, error);
-				}
-
-				throw new DegitError(`could not clone ${repo.url}`, {
-					code: 'COULD_NOT_FETCH',
-					original: error,
-					url: repo.url,
-				});
-			}
-		},
-	};
+	throw new DegitError(`could not ${action} ${repo.url}`, {
+		code: 'COULD_NOT_FETCH',
+		original: error,
+		url: repo.url,
+	});
 }
 
-export const defaultGitClient = createGitClient();
+export const defaultGitClient: GitClient = {
+	async fetchRefs(repo) {
+		try {
+			return repo.transport === 'ssh'
+				? await fetchRefsWithGitCli(repo)
+				: await fetchRefsWithIsomorphicGit(repo);
+		} catch (error) {
+			wrapGitError(repo, error, repo.transport, 'fetch');
+		}
+	},
+
+	async clone(repo, dest, ref, transport = repo.transport) {
+		try {
+			if (transport === 'ssh') {
+				await cloneWithGitCli(repo, dest, ref, transport);
+			} else {
+				await cloneWithIsomorphicGit(repo, dest, ref, transport);
+			}
+		} catch (error) {
+			wrapGitError(repo, error, transport, 'clone');
+		}
+	},
+};

--- a/src/transports/tar/archive.ts
+++ b/src/transports/tar/archive.ts
@@ -1,7 +1,7 @@
 import { constants, cp, mkdtemp, readFile, readdir, rm, access } from 'node:fs/promises';
 import path from 'node:path';
 import * as tar from 'tar';
-import { getProvider, type Repo } from '../../domain/repo.js';
+import { providerArchiveTemplates, type Repo } from '../../domain/repo.js';
 import { readCachedRefs, updateCache } from './cache.js';
 import { DegitError, mkdirp } from '../../shared/utils.js';
 import type { EventInfo, FetchFn } from '../../domain/types.js';
@@ -55,17 +55,10 @@ async function resolveArchiveHash(
 }
 
 async function createArchiveSource(dir: string, repo: Repo, hash: string): Promise<ArchiveSource> {
-	const provider = getProvider(repo.site);
-	if (!provider) {
-		throw new DegitError(`degit supports GitHub, GitLab, Sourcehut and BitBucket`, {
-			code: 'UNSUPPORTED_HOST',
-		});
-	}
-
 	return {
 		file: path.join(dir, `${hash}.tar.gz`),
 		subdir: null,
-		url: provider.archiveUrl(repo, hash),
+		url: providerArchiveTemplates[repo.site](repo, hash),
 		workDir: await mkdtemp(path.join(dir, 'extract-')),
 	};
 }
@@ -176,8 +169,19 @@ async function extractArchive(context: TarContext, source: ArchiveSource, dest: 
 			message: `extracting ${source.subdir ? `${context.repo.subdir} from ` : ''}${source.file} to ${source.workDir}`,
 		});
 
+		const [strip, files] = source.subdir
+			? [source.subdir.split('/').length, [source.subdir]]
+			: [1, []];
+
 		await withArchiveRetry(context, source, () =>
-			untar(source.file, source.workDir, source.subdir),
+			tar.extract(
+				{
+					C: source.workDir,
+					file: source.file,
+					strip,
+				},
+				files,
+			),
 		);
 		const hasPointers = await hasGitLfsPointers(source.workDir);
 		if (!hasPointers) {
@@ -254,17 +258,6 @@ export async function cloneWithTar(context: TarContext, dir: string, dest: strin
 	}
 
 	await updateCache(dir, context.repo, hash, cached);
-}
-
-function untar(file: string, dest: string, subdir: string | null = null) {
-	return tar.extract(
-		{
-			C: dest,
-			file,
-			strip: subdir ? subdir.split('/').length : 1,
-		},
-		subdir ? [subdir] : [],
-	);
 }
 
 async function hasGitLfsPointers(dir: string): Promise<boolean> {

--- a/src/transports/tar/cache.ts
+++ b/src/transports/tar/cache.ts
@@ -1,19 +1,10 @@
-import { timingSafeEqual } from 'node:crypto';
 import { rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { Repo } from '../../domain/repo.js';
-import { tryRequire } from '../../shared/utils.js';
-
-function sameHash(left: string | undefined, right: string) {
-	if (!left || left.length !== right.length) {
-		return false;
-	}
-
-	return timingSafeEqual(Buffer.from(left), Buffer.from(right));
-}
+import { tryReadJson } from '../../shared/utils.js';
 
 export function readCachedRefs(dir: string) {
-	return (tryRequire(path.join(dir, 'map.json')) || {}) as Record<string, string>;
+	return (tryReadJson(path.join(dir, 'map.json')) || {}) as Record<string, string>;
 }
 
 export async function updateCache(
@@ -23,26 +14,28 @@ export async function updateCache(
 	cached: Record<string, string>,
 ) {
 	const cache = new Map(Object.entries(cached));
-	const logs = tryRequire(path.join(dir, 'access.json')) || {};
+	const logs = tryReadJson(path.join(dir, 'access.json')) || {};
 	logs[repo.ref] = new Date().toISOString();
 	// Dynamic cache file paths are derived from repo/ref values within the cache root.
 	// eslint-disable-next-line security/detect-non-literal-fs-filename
 	await writeFile(path.join(dir, 'access.json'), JSON.stringify(logs, null, '  '));
 
 	const currentHash = cache.get(repo.ref);
-	if (sameHash(currentHash, hash)) {
+	// ponytail: public commit hashes compared with ===; no timing-attack resistance needed for local cache files. Upgrade to crypto.timingSafeEqual if hashes ever become secret.
+	// oxlint-disable-next-line security/detect-possible-timing-attacks
+	if (currentHash === hash) {
 		return;
 	}
 
-	if (currentHash && ![...cache.values()].some((value) => sameHash(value, hash))) {
+	cache.set(repo.ref, hash);
+
+	if (currentHash && ![...cache.values()].includes(currentHash)) {
 		try {
 			await rm(path.join(dir, `${currentHash}.tar.gz`), { force: true, recursive: true });
 		} catch {
 			// Ignore cache cleanup failures.
 		}
 	}
-
-	cache.set(repo.ref, hash);
 	// Dynamic cache file paths are derived from repo/ref values within the cache root.
 	// eslint-disable-next-line security/detect-non-literal-fs-filename
 	await writeFile(

--- a/src/transports/tar/cache.ts
+++ b/src/transports/tar/cache.ts
@@ -21,7 +21,7 @@ export async function updateCache(
 	await writeFile(path.join(dir, 'access.json'), JSON.stringify(logs, null, '  '));
 
 	const currentHash = cache.get(repo.ref);
-	// ponytail: public commit hashes compared with ===; no timing-attack resistance needed for local cache files. Upgrade to crypto.timingSafeEqual if hashes ever become secret.
+	// Public commit hashes are not secret; direct equality is safe for local cache files.
 	// oxlint-disable-next-line security/detect-possible-timing-attacks
 	if (currentHash === hash) {
 		return;

--- a/test/unit/filesystem.test.ts
+++ b/test/unit/filesystem.test.ts
@@ -129,12 +129,16 @@ describe('filesystem', () => {
 
 		try {
 			fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+			fs.mkdirSync(path.join(root, 'src2'), { recursive: true });
 			fs.writeFileSync(path.join(root, 'src', 'index.ts'), 'index');
+			fs.writeFileSync(path.join(root, 'src2', 'sibling.ts'), 'sibling');
 			fs.writeFileSync(path.join(root, 'README.md'), 'readme');
 
 			const warnings = runKeepFiles(root, ['src']);
 
 			assert.equal(fs.existsSync(path.join(root, 'src', 'index.ts')), true);
+			assert.equal(fs.existsSync(path.join(root, 'src2')), false);
+			assert.equal(fs.existsSync(path.join(root, 'src2', 'sibling.ts')), false);
 			assert.equal(fs.existsSync(path.join(root, 'README.md')), false);
 			assert.deepEqual(warnings, []);
 		} finally {

--- a/test/unit/git-client.test.ts
+++ b/test/unit/git-client.test.ts
@@ -72,7 +72,7 @@ vi.mock('isomorphic-git/http/node', () => ({
 	default: {},
 }));
 
-const { createGitClient } = await import('../../src/transports/git/client.js');
+const { defaultGitClient } = await import('../../src/transports/git/client.js');
 
 /* eslint-disable max-lines-per-function */
 describe('git client', () => {
@@ -152,7 +152,7 @@ describe('git client', () => {
 			refs: [{ oid: '0123456789abcdef0123456789abcdef01234567', ref: 'refs/heads/main' }],
 		});
 
-		const refs = await createGitClient().fetchRefs(httpsRepo);
+		const refs = await defaultGitClient.fetchRefs(httpsRepo);
 
 		assert.deepEqual(refs, [
 			{
@@ -167,7 +167,7 @@ describe('git client', () => {
 	});
 
 	it('uses the planned branch when cloning over https', async () => {
-		await createGitClient().clone(httpsRepo, '.tmp/git-client-test', 'main');
+		await defaultGitClient.clone(httpsRepo, '.tmp/git-client-test', 'main');
 
 		assert.equal(cloneMock.mock.calls.length, 1);
 		assert.deepEqual(
@@ -221,7 +221,7 @@ describe('git client', () => {
 			return child;
 		});
 
-		const refs = await createGitClient().fetchRefs(sshRepo);
+		const refs = await defaultGitClient.fetchRefs(sshRepo);
 
 		assert.equal(refs.length, 101);
 		assert.deepEqual(refs[0], {
@@ -241,7 +241,7 @@ describe('git client', () => {
 	});
 
 	it('reports a missing git binary when fetching refs over ssh', async () => {
-		await assert.rejects(createGitClient().fetchRefs(sshRepo), (error: any) => {
+		await assert.rejects(defaultGitClient.fetchRefs(sshRepo), (error: any) => {
 			assert.equal(error.code, 'GIT_NOT_FOUND');
 			assert.match(error.message, /git is not installed/u);
 			return true;
@@ -261,7 +261,7 @@ describe('git client', () => {
 		);
 
 		await assert.rejects(
-			createGitClient().clone(sshRepo, '.tmp/git-client-test'),
+			defaultGitClient.clone(sshRepo, '.tmp/git-client-test'),
 			(error: any) => {
 				assert.equal(error.code, 'GIT_NOT_FOUND');
 				assert.match(error.message, /git is not installed/u);
@@ -271,7 +271,7 @@ describe('git client', () => {
 	});
 
 	it('uses a shallow clone when cloning over ssh', async () => {
-		await createGitClient().clone(sshRepo, '.tmp/git-client-test');
+		await defaultGitClient.clone(sshRepo, '.tmp/git-client-test');
 
 		assert.equal(execFileMock.mock.calls[0][0], 'git');
 		assert.deepEqual(execFileMock.mock.calls[0][1], [

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -3,7 +3,13 @@ import https from 'node:https';
 import assert from 'node:assert';
 import path from 'node:path';
 import { describe, it, vi } from 'vitest';
-import { fetch, resolveBase, stashFiles, unstashFiles } from '../../src/shared/utils.js';
+import {
+	fetch,
+	resolveBase,
+	safeResolve,
+	stashFiles,
+	unstashFiles,
+} from '../../src/shared/utils.js';
 
 /* eslint-disable max-lines-per-function */
 describe('shared utils', () => {
@@ -137,6 +143,21 @@ describe('shared utils', () => {
 			createWriteStreamSpy.mockRestore();
 			getSpy.mockRestore();
 		}
+	});
+
+	it('rejects paths that resolve to the destination root when a root-like path is given', () => {
+		const root = path.resolve('/tmp/degit-safe-test');
+		assert.equal(safeResolve(root, '.'), undefined);
+		assert.equal(safeResolve(root, ''), undefined);
+		assert.equal(safeResolve(root, 'foo/..'), undefined);
+		assert.equal(safeResolve(root, 'foo'), path.join(root, 'foo'));
+	});
+
+	it('rejects absolute paths and multi-level dot-dot escapes when resolving inside the root', () => {
+		const root = path.resolve('/tmp/degit-safe-test');
+		assert.equal(safeResolve(root, path.join(root, '..', 'outside')), undefined);
+		assert.equal(safeResolve(root, 'foo/../../outside'), undefined);
+		assert.equal(safeResolve(root, 'foo'), path.join(root, 'foo'));
 	});
 });
 /* eslint-enable max-lines-per-function */


### PR DESCRIPTION
- Replace custom Provider/getProvider switch with providerDomains records
- Use node:events.EventEmitter instead of hand-rolled listener arrays
- Compare cache hashes with === and remove timingSafeEqual wrapper
- Replace custom mkdirp recursion with fs.mkdirSync recursive
- Read JSON cache files with fs.readFileSync + JSON.parse
- Simplify bin version lookup to a single package.json URL
- Add shared safeRelative helper for path-escape checks
- Reuse resolveAlias from aliases module
- Drop hasUserKeeps flag and fix keepFiles directory-prefix matching
- Inline one-call untar wrapper into tar extraction
- Use fs.rmSync for both files and directories in removeFile
- Replace promise reduce in applyDirectives with for...of await
- Use delete aliases[name] in removeAlias
- Export defaultGitClient object directly

Co-Authored-By: Devin <158243242+devin-ai-integration[bot]@users.noreply.github.com>
