### PR TITLE
feat: add --repo-name flag to clone into a directory named after the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Download to a new folder:
 
 ```bash
 degit user/repo my-new-project
+degit -r user/repo
 ```
 
 Download only specific files:

--- a/assets/help.md
+++ b/assets/help.md
@@ -57,6 +57,7 @@ Options:
 `--cache`, `-c` Only use local cache (no network)
 `--force`, `-f` Allow non-empty destination directory
 `--files <paths>`, `-F <paths>` Clone only the listed files or directories (comma-separated)
+`--repo-name`, `-r` Clone into a directory named after the repository
 `--verbose`, `-v` Extra logging
 
 Without `--cache`, degit tries the network first and falls back to the local cache if the network is unreachable.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # degit changelog
 
+## Unreleased
+
+- Add `--repo-name` / `-r` flag to clone into a directory named after the repository ([#42](https://github.com/Rich-Harris/degit/issues/42)).
+
 ## 3.7.1
 
 - Reject `remove` and `keep` directives that resolve to the destination root, preventing a `degit.json` action from deleting the whole clone.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -103,10 +103,11 @@ If you omit the ref, `degit` resolves the repository's default branch.
 
 ### Create a new folder
 
-If `dest` is omitted, `degit` extracts into the current directory. The directory must be empty unless you use `--force`.
+If `dest` is omitted, `degit` extracts into the current directory. The directory must be empty unless you use `--force`. Use `--repo-name` or `-r` to extract into a directory named after the repository instead:
 
 ```bash
 degit user/repo my-new-project
+degit -r user/repo
 ```
 
 ### Clone a subdirectory
@@ -145,6 +146,7 @@ Missing or out-of-bounds paths are skipped with a warning; if no requested paths
 | `--cache`         | `-c`         | Only use the local cache; do not hit the network.                                                     |
 | `--force`         | `-f`         | Allow cloning into a non-empty destination directory.                                                 |
 | `--files <paths>` | `-F <paths>` | Keep only the listed files or directories.                                                            |
+| `--repo-name`     | `-r`         | Clone into a directory named after the repository.                                                    |
 | `--verbose`       | `-v`         | Print extra progress information.                                                                     |
 | `--mode <mode>`   | `-m`         | `tar` (default) or `git`. `--mode=git` is accepted for compatibility but prints a deprecation notice. |
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -4,6 +4,7 @@ import enquirer from 'enquirer';
 import fuzzysearch from 'fuzzysearch';
 import mri from 'mri';
 import glob from 'tiny-glob/sync.js';
+import { parse } from './domain/repo.js';
 import degit from './index.js';
 import {
 	handleAliasSubcommand,
@@ -27,6 +28,7 @@ type CliArgs = {
 	force?: boolean;
 	help?: boolean;
 	mode?: string;
+	'repo-name'?: boolean;
 	verbose?: boolean;
 	version?: boolean;
 };
@@ -58,10 +60,11 @@ function parseCliArgs(argv: string[]) {
 			f: 'force',
 			F: 'files',
 			m: 'mode',
+			r: 'repo-name',
 			v: 'verbose',
 			V: 'version',
 		},
-		boolean: ['force', 'cache', 'verbose', 'version'],
+		boolean: ['force', 'cache', 'repo-name', 'verbose', 'version'],
 		string: ['files', 'mode'],
 	}) as CliArgs;
 }
@@ -194,7 +197,7 @@ function normalizeFiles(files: string | string[] | boolean | undefined): string[
 export async function main(argv: string[]) {
 	const args = parseCliArgs(argv);
 
-	const [src, dest = '.'] = args._;
+	const [src, positionalDest] = args._;
 
 	if (args.help) {
 		displayHelp();
@@ -227,8 +230,10 @@ export async function main(argv: string[]) {
 	}
 
 	const aliases = loadAliases();
+	const resolvedSrc = resolveAlias(aliases, src) ?? src;
+	const dest = positionalDest ?? (args['repo-name'] ? parse(resolvedSrc).name : '.');
 	const files = normalizeFiles(args.files);
-	run(resolveAlias(aliases, src) ?? src, dest, { ...args, aliases, files });
+	run(resolvedSrc, dest, { ...args, aliases, files });
 }
 
 /* eslint-enable security/detect-non-literal-fs-filename */

--- a/test/unit/bin.test.ts
+++ b/test/unit/bin.test.ts
@@ -218,6 +218,37 @@ describe('degit bin', () => {
 		assert.equal(instance.clone.mock.calls[0][0], 'out');
 	});
 
+	it('clones into the repo name when argv passes -r without a destination', async () => {
+		await main(['node', 'bin', 'user/repo', '-r']);
+		assert.equal(mockDegit.mock.calls.length, 1);
+		assert.equal(mockDegit.mock.calls[0][0], 'user/repo');
+		const instance = mockDegit.mock.results[0].value;
+		assert.equal(instance.clone.mock.calls[0][0], 'repo');
+	});
+
+	it('clones into the repo name when argv passes --repo-name', async () => {
+		await main(['node', 'bin', 'user/repo', '--repo-name']);
+		assert.equal(mockDegit.mock.calls.length, 1);
+		assert.equal(mockDegit.mock.calls[0][0], 'user/repo');
+		const instance = mockDegit.mock.results[0].value;
+		assert.equal(instance.clone.mock.calls[0][0], 'repo');
+	});
+
+	it('uses the explicit destination when argv passes -r with a destination', async () => {
+		await main(['node', 'bin', 'user/repo', 'out', '-r']);
+		assert.equal(mockDegit.mock.calls.length, 1);
+		const instance = mockDegit.mock.results[0].value;
+		assert.equal(instance.clone.mock.calls[0][0], 'out');
+	});
+
+	it('clones into the resolved repo name when argv passes -r with an alias', async () => {
+		saveAlias('myRepo', 'github:user/aliased#v1.0.0');
+		await main(['node', 'bin', 'myRepo', '-r']);
+		assert.equal(mockDegit.mock.calls[0][0], 'github:user/aliased#v1.0.0');
+		const instance = mockDegit.mock.results[0].value;
+		assert.equal(instance.clone.mock.calls[0][0], 'aliased');
+	});
+
 	it('presents empty choices when the cache directory does not exist', async () => {
 		fs.rmSync(base, { force: true, recursive: true });
 


### PR DESCRIPTION
## Summary

**What**

Adds a `--repo-name` / `-r` CLI flag that derives the clone destination from the repository name, so `degit -r user/repo` clones into `repo/` instead of the current directory.

**Why**

Today, omitting the destination extracts into the current directory, which means the common "clone this template into its own folder" case forces you to retype the repo name (`degit user/repo repo`). This closes that gap without changing any existing invocation.

## Linked issues

Closes #42

## Changes

- `src/bin.ts` — registers `repo-name` as a boolean `mri` option with the `r` alias, and resolves the destination as `positionalDest ?? (args['repo-name'] ? parse(resolvedSrc).name : '.')`. Alias resolution happens *before* parsing, so `-r` works with saved aliases.
- `assets/help.md`, `docs/USAGE.md`, `README.md` — document the new option; `docs/CHANGELOG.md` gains an Unreleased entry.
- `test/unit/bin.test.ts` — four new tests covering `-r`, `--repo-name`, explicit-destination precedence, and alias resolution.

Behavior notes for reviewers:

- **An explicit destination always wins.** `degit -r user/repo out` still clones into `out/`. The flag only fills in a destination that was omitted, so no existing command changes behavior.
- `repo-name` had to be declared in `mri`'s `boolean` list. Without it, `degit --repo-name user/repo` parses the source as the flag's *value* (`{ _: [], 'repo-name': 'user/repo' }`) and the source is silently swallowed.
- The directory name comes from the already-parsed `repo.name`, which strips a trailing `.git` and is always a single path segment — refs (`#v1.0.0`), subdirectories, provider prefixes, and full URLs all resolve to the bare repo name.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`) — 179 passed, up from 178; includes the live-network integration suite
- [x] Manual / CLI check if user-facing behavior changed — `node degit -r Rich-Harris/degit-test-repo` created `degit-test-repo/`; `degit --help` renders the new option
- [ ] CI passes — not yet observed; this box is for the reviewer once the run completes

Also run locally: `bun run typecheck`, `bun run lint` (0 warnings), `bun run format:ci`, `bun run knip:ci`, `bun run duplicates:ci`, `bun audit`.

## Review notes

**Breaking changes** — none. The flag is additive and inert unless passed; destination resolution is unchanged when a positional destination is supplied.

**Risks / rollout** — low. The change is confined to CLI argument handling; no transport, cache, archive, git, or filesystem logic was touched.

**Focus areas for reviewers**

- The precedence choice is the one judgement call worth confirming: `-r` only applies when the destination is *omitted*, rather than overriding an explicit one. Issue #42 doesn't state which is intended, and the opposite reading is defensible.
- Error handling on an invalid source with `-r`: `parse()` now runs slightly earlier than before. This was verified to be a non-issue — `src/core/orchestrator.ts` calls the same `parse()` in the `Degit` constructor and `run()` is invoked synchronously from `main()`, so `degit bad out` and `degit -r bad` produce byte-identical stderr and the same `BAD_SRC` code.
- Degenerate names such as `degit -r user/..` are caught by the existing non-empty-destination guard and the remote 404 before anything is written.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
