### PR TITLE
Add release automation workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: release
+on:
+  push:
+    tags: ["v*"]
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get version from tag
+        id: tag_name
+        run: echo "current_version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+        shell: bash
+      - uses: actions/checkout@v4
+      - uses: mindsers/changelog-reader-action@v2
+        id: log
+        with:
+          version: ${{ steps.tag_name.outputs.current_version }}
+          path: ./docs/CHANGELOG.md
+      - uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.log.outputs.changes }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,250 +1,250 @@
 # degit changelog
 
-## 3.9.0
+## [3.9.0]
 
 - Add `Degit#doActions()` for programmatic `degit.json` actions and make the constructor source-optional ([#33](https://github.com/Rich-Harris/degit/issues/33)).
 
-## 3.8.0
+## [3.8.0]
 
 - Add `--repo-name` / `-r` flag to clone into a directory named after the repository ([#42](https://github.com/Rich-Harris/degit/issues/42)).
 - Support glob patterns in the `remove` action's `files` list behind the `allowGlobs` flag ([#148](https://github.com/Rich-Harris/degit/issues/148)).
 
-## 3.7.1
+## [3.7.1]
 
 - Reject `remove` and `keep` directives that resolve to the destination root, preventing a `degit.json` action from deleting the whole clone.
 - Fix `--help` crash on Node 20.10 caused by `import.meta.dirname` being undefined before Node 20.11.
 - Fix interactive cache prompt crash on corrupt `access.json`.
 
-## 3.7.0
+## [3.7.0]
 
 - Redownload cached tar archives when extraction fails with any tar/zlib error, not only `TAR_BAD_ARCHIVE` ([#41](https://github.com/Rich-Harris/degit/issues/41)).
 - Added `files` option to clone only specific files or directories ([#129](https://github.com/Rich-Harris/degit/issues/129)).
 
-## 3.6.6
+## [3.6.6]
 
 - Support GitLab nested groups by probing candidate `user/repo` paths at runtime ([#76](https://github.com/Rich-Harris/degit/issues/76)).
 - Clarify `--cache` flag and default offline fallback behavior in help text and README ([#314](https://github.com/Rich-Harris/degit/issues/314)).
 - Add a JSON Schema for `degit.json` at `schemas/degit.schema.json`.
 - Decode URL-encoded subdirectory segments in full repository URLs ([#477](https://github.com/Rich-Harris/degit/issues/477)).
 
-## 3.6.5
+## [3.6.5]
 
 - Fix interactive mode crash when the cache directory does not exist ([#345](https://github.com/Rich-Harris/degit/issues/345)).
 - Add repository aliases to the CLI ([#362](https://github.com/Rich-Harris/degit/issues/362)).
 - Respect `repo.subdir` and report the correct `mode` when using `mode: 'git'` ([#349](https://github.com/Rich-Harris/degit/issues/349)).
 - Throw an error instead of creating an empty destination when the requested subdirectory does not exist in git mode ([#331](https://github.com/Rich-Harris/degit/issues/331)).
 
-## 3.6.4
+## [3.6.4]
 
 - Add `--version` / `-V` flag to print the package version.
 
-## 3.6.3
+## [3.6.3]
 
 - Accept full subdirectory URLs containing branch path segments such as `/tree/main/...` ([#370](https://github.com/Rich-Harris/degit/issues/370)).
 
-## 3.6.2
+## [3.6.2]
 
 - Fix Bitbucket subdirectory clones that silently create an empty directory ([#371](https://github.com/Rich-Harris/degit/issues/371)).
 
-## 3.6.1
+## [3.6.1]
 
 - Load `degit.json` as JSON instead of an executable module.
 - Fix HTTPS clones with explicit refs throwing a `ReferenceError`.
 
-## 3.6.0
+## [3.6.0]
 
 - Add `gitlab://host/user/repo` syntax for cloning from self-hosted GitLab instances (thanks to @dnldsht for the original PR #361).
 
-## 3.5.1
+## [3.5.1]
 
 - Fix GitLab archive URL format and centralize provider templates (thanks to @satotake for the original PR #335).
 
-## 3.5.0
+## [3.5.0]
 
 - Add a `search_replace` action for `degit.json` (thanks to @Tythos for the original PR #365).
 
-## 3.4.7
+## [3.4.7]
 
 - Gate clone error details behind `--verbose`.
 
-## 3.4.6
+## [3.4.6]
 
 - Block `remove` path traversal outside the destination.
 
-## 3.4.5
+## [3.4.5]
 
 - Stream `git ls-remote` for SSH ref discovery.
 
-## 3.4.4
+## [3.4.4]
 
 - Remove the `sander` dependency in favor of native Node `fs` helpers.
 
-## 3.4.3
+## [3.4.3]
 
 - Swap terminal colors to yoctocolors.
 
-## 3.4.2
+## [3.4.2]
 
 - Fix git-lfs pointer files falling through the tarball path.
 
-## 3.4.1
+## [3.4.1]
 
 - Fix first-clone hangs during archive downloads.
 
-## 3.4.0
+## [3.4.0]
 
 - Tarball downloads are now the default, with SSH fallback on failure.
 - Public remotes now prefer HTTPS; explicit SSH sources still use SSH.
 - The JavaScript git backend is bundled for HTTPS ref discovery; SSH/private repos still need system `git`.
 - The published package no longer includes sourcemaps, so the tarball is smaller.
 
-## 3.3.2
+## [3.3.2]
 
 - Retry corrupt tarball downloads (issue #313).
 
-## 3.3.1
+## [3.3.1]
 
 - Harden git-mode command execution and remote validation.
 
-## 3.3.0
+## [3.3.0]
 
 - Add platform-aware cache resolution so degit uses the standard user cache location on each supported OS ([#45](https://github.com/Rich-Harris/degit/issues/45)).
 
-## 3.2.0
+## [3.2.0]
 
 - Split CLI output by severity so info messages go to stdout while warnings and errors stay on stderr ([#382](https://github.com/Rich-Harris/degit/issues/382)).
 
-## 3.1.2
+## [3.1.2]
 
 - Fix interactive repo selection on Windows.
 
-## 3.1.1
+## [3.1.1]
 
 - Sync `assets/help.md` to say branches default to the repository's default branch.
 
-## 3.1.0
+## [3.1.0]
 
 - Add new type definitions for the published package surface.
 
-## 3.0.0
+## [3.0.0]
 
 - Major release for the Node 20+ line; v2 remains the legacy Node 8-compatible branch.
 - Upgrade `tar` to a patched release to address the security issue that affected the previous dependency.
 
-## 2.8.6
+## [2.8.6]
 
 - Harden git-mode command execution and remote validation.
 
-## 2.8.5
+## [2.8.5]
 
 - Final v2 security patch; keep Node 8 compatibility on the legacy line.
 - Node 20 starts with v3.
 
-## 2.8.4
+## [2.8.4]
 
 - Whoops
 
-## 2.8.3
+## [2.8.3]
 
 - Reinstate `#!/usr/bin/env node` ([#273](https://github.com/Rich-Harris/degit/issues/273))
 
-## 2.8.2
+## [2.8.2]
 
 - Fix `bin`/`main` locations ([#273](https://github.com/Rich-Harris/degit/issues/273))
 - Update dependencies
 
-## 2.8.1
+## [2.8.1]
 
 - Use `HEAD` instead of `master` ([#243](https://github.com/Rich-Harris/degit/pull/243)])
 
-## 2.8.0
+## [2.8.0]
 
 - Sort by recency in interactive mode
 
-## 2.7.0
+## [2.7.0]
 
 - Bundle for a faster install
 
-## 2.6.0
+## [2.6.0]
 
 - Add an interactive mode ([#4](https://github.com/Rich-Harris/degit/issues/4))
 
-## 2.5.0
+## [2.5.0]
 
 - Add `--mode=git` for cloning private repos ([#29](https://github.com/Rich-Harris/degit/pull/29))
 
-## 2.4.0
+## [2.4.0]
 
 - Clone subdirectories from repos (`user/repo/subdir`)
 
-## 2.3.0
+## [2.3.0]
 
 - Support HTTPS proxying where `https_proxy` env var is supplied ([#26](https://github.com/Rich-Harris/degit/issues/26))
 
-## 2.2.2
+## [2.2.2]
 
 - Improve CLI error logging ([#49](https://github.com/Rich-Harris/degit/pull/49))
 
-## 2.2.1
+## [2.2.1]
 
 - Update `help.md` for Sourcehut support
 
-## 2.2.0
+## [2.2.0]
 
 - Sourcehut support ([#85](https://github.com/Rich-Harris/degit/pull/85))
 
-## 2.1.4
+## [2.1.4]
 
 - Fix actions ([#65](https://github.com/Rich-Harris/degit/pull/65))
 - Improve CLI error logging ([#46](https://github.com/Rich-Harris/degit/pull/46))
 
-## 2.1.3
+## [2.1.3]
 
 - Install `sander` ([#34](https://github.com/Rich-Harris/degit/issues/34))
 
-## 2.1.2
+## [2.1.2]
 
 - Remove `console.log`
 
-## 2.1.1
+## [2.1.1]
 
 - Oops, managed to publish 2.1.0 without building
 
-## 2.1.0
+## [2.1.0]
 
 - Add actions ([#28](https://github.com/Rich-Harris/degit/pull/28))
 
-## 2.0.2
+## [2.0.2]
 
 - Allow flags like `-v` before argument ([#25](https://github.com/Rich-Harris/degit/issues/25))
 
-## 2.0.1
+## [2.0.1]
 
 - Update node-tar for Node 9 compatibility
 
-## 2.0.0
+## [2.0.0]
 
 - Expose API for use in Node scripts ([#23](https://github.com/Rich-Harris/degit/issues/23))
 
-## 1.2.2
+## [1.2.2]
 
 - Fix `files` in package.json
 
-## 1.2.1
+## [1.2.1]
 
 - Add `engines` field ([#17](https://github.com/Rich-Harris/degit/issues/17))
 
-## 1.2.0
+## [1.2.0]
 
 - Windows support ([#1](https://github.com/Rich-Harris/degit/issues/1))
 - Offline support and `--cache` flag ([#8](https://github.com/Rich-Harris/degit/issues/8))
 - `degit --help` ([#5](https://github.com/Rich-Harris/degit/issues/5))
 - `--verbose` flag
 
-## 1.1.0
+## [1.1.0]
 
 - Use HTTPS, not SSH ([#11](https://github.com/Rich-Harris/degit/issues/11))
 
-## 1.0.0
+## [1.0.0]
 
 - First release


### PR DESCRIPTION
Adds a GitHub Actions workflow that creates a GitHub Release automatically whenever a `v*` tag is pushed, using the matching section of `docs/CHANGELOG.md` as the release notes.

Two changes:

- **`.github/workflows/release.yml`** - on a `v*` tag push, strips the `v` from the tag, reads the corresponding version entry from `docs/CHANGELOG.md` with `mindsers/changelog-reader-action`, and publishes it as a GitHub Release via `softprops/action-gh-release`.
- **`docs/CHANGELOG.md`** - converts all 57 version headers to Keep a Changelog format (`## [3.9.0]` instead of `## 3.9.0`), which the changelog-reader action requires. No content changes beyond the headers.