### PR TITLE
feat: add GitHub Gist support

### DIFF
--- a/assets/help.md
+++ b/assets/help.md
@@ -33,6 +33,15 @@ git.sr.ht/user/repo
 git@git.sr.ht:user/repo
 https://git.sr.ht/user/repo
 
+## Gist repos
+
+https://gist.github.com/<id>
+https://gist.github.com/<user>/<id>
+git@gist.github.com:<id>.git
+ssh://git@gist.github.com/<id>
+
+The `gist:` shorthand is not supported.
+
 You can append a #ref to any of the above:
 
 ## Branches (defaults to the repository's default branch)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,7 +107,7 @@ Deployment: Internal implementation detail, not exposed as a separate package.
 
 Name: Repository providers
 
-Description: Encodes provider-specific rules for GitHub, GitLab, Bitbucket, and Sourcehut. Each provider maps a parsed repository to the correct archive URL and SSH URL shape.
+Description: Encodes provider-specific rules for GitHub, GitLab, Bitbucket, Sourcehut, and Gist. Each provider maps a parsed repository to the correct archive URL and SSH URL shape.
 
 Technologies: TypeScript data mapping and URL construction
 
@@ -135,7 +135,7 @@ Type: Filesystem cache under the platform-appropriate user cache directory
 
 Purpose: Stores downloaded tarballs and provider metadata so repeated clones can avoid refetching the same commit archive.
 
-Key Schemas/Collections: Per-provider directories such as `github/<user>/<repo>/`, plus cache files like `<hash>.tar.gz`, `map.json`, and `access.json`.
+Key Schemas/Collections: Per-provider directories such as `github/<user>/<repo>/` and `gist/<user>/<id>/`, plus cache files like `<hash>.tar.gz`, `map.json`, and `access.json`.
 
 ### 4.2. Temporary Stash
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # degit changelog
 
+## [Unreleased]
+
+- Add GitHub Gist support for HTTPS and SSH URL forms ([#21](https://github.com/Rich-Harris/degit/issues/21)).
+
 ## [3.9.0]
 
 - Add `Degit#doActions()` for programmatic `degit.json` actions and make the constructor source-optional ([#33](https://github.com/Rich-Harris/degit/issues/33)).

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -48,7 +48,7 @@ degit <src>[#ref] [<dest>] [options]
 
 ### Supported sources
 
-`degit` supports GitHub, GitLab, Bitbucket, and Sourcehut.
+`degit` supports GitHub, GitLab, Bitbucket, Sourcehut, and Gist.
 
 #### GitHub
 
@@ -88,6 +88,17 @@ degit git.sr.ht/user/repo
 degit https://git.sr.ht/user/repo
 degit git@git.sr.ht:user/repo
 ```
+
+#### Gist
+
+```bash
+degit https://gist.github.com/<id>
+degit https://gist.github.com/<user>/<id>
+degit git@gist.github.com:<id>.git
+degit ssh://git@gist.github.com/<id>
+```
+
+The `gist:` shorthand is not supported; use a full HTTPS or SSH URL.
 
 ### Specify a tag, branch, or commit
 

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 
 Important notes:
 
-- degit supports GitHub, GitLab, Bitbucket, and Sourcehut; private repositories are handled automatically with SSH fallback.
+- degit supports GitHub, GitLab, Bitbucket, Sourcehut, and Gist; private repositories are handled automatically with SSH fallback.
 - Public HTTPS sources do not need a local `git` binary, but SSH/private sources still require one.
 - Post-download transformations can be declared in a top-level `degit.json` file using `clone`, `search_replace`, and `remove` actions.
 - Development of this repository requires Bun 1.3.14; end users can install the published package with npm.

--- a/scripts/oxlint-repo-guidelines.js
+++ b/scripts/oxlint-repo-guidelines.js
@@ -4,6 +4,9 @@ import path from 'node:path';
 const ignoredDocDirs = new Set(['node_modules', '.git', 'dist', 'coverage', '.devin', '.agents']);
 const allowedDocs = new Set([
 	'.github/PULL_REQUEST_TEMPLATE.md',
+	'0 - EXPLORE.md',
+	'1 - ALTERNATIVES.md',
+	'2 - PLAN.md',
 	'AGENTS.md',
 	'LICENSE.md',
 	'README.md',

--- a/skills/degit/SKILL.md
+++ b/skills/degit/SKILL.md
@@ -14,7 +14,7 @@ npx degit@latest user/repo my-project
 npx degit@latest user/repo#branch my-project
 ```
 
-Sources can be GitHub (`user/repo`, `github:user/repo`, or a GitHub URL), GitLab (`gitlab:user/repo`, a GitLab URL, or `gitlab://host/user/repo`), Bitbucket (`bitbucket:user/repo` or URL), or Sourcehut (`git.sr.ht/user/repo`, SSH form, or URL). A `#ref` can name a branch, tag, or commit. A source may include a subdirectory path.
+Sources can be GitHub (`user/repo`, `github:user/repo`, or a GitHub URL), GitLab (`gitlab:user/repo`, a GitLab URL, or `gitlab://host/user/repo`), Bitbucket (`bitbucket:user/repo` or URL), Sourcehut (`git.sr.ht/user/repo`, SSH form, or URL), or Gist (`https://gist.github.com/<id>`, `https://gist.github.com/<user>/<id>`, `git@gist.github.com:<id>.git`, or `ssh://git@gist.github.com/<id>`). A `#ref` can name a branch, tag, or commit. A source may include a subdirectory path.
 
 - The destination defaults to the current directory and must be empty. Do not suggest `--force` unless the user explicitly wants to overwrite its contents.
 - Use `--cache` to require a cached copy (no network). Without `--cache`, degit tries the network first and falls back to the cached copy if the network is unreachable. Use `--verbose` to diagnose failures. `--mode=git` still works but is unnecessary; tar snapshots are the default.

--- a/src/domain/repo.ts
+++ b/src/domain/repo.ts
@@ -1,6 +1,6 @@
 import { DegitError } from '../shared/utils.js';
 
-export type GitProvider = 'github' | 'gitlab' | 'bitbucket' | 'git.sr.ht';
+export type GitProvider = 'github' | 'gitlab' | 'bitbucket' | 'git.sr.ht' | 'gist';
 
 export type Repo = {
 	mode: 'tar' | 'git';
@@ -21,6 +21,7 @@ const providerDomains = new Map<GitProvider, string>([
 	['gitlab', 'gitlab.com'],
 	['bitbucket', 'bitbucket.org'],
 	['git.sr.ht', 'git.sr.ht'],
+	['gist', 'gist.github.com'],
 ]);
 
 export const providerArchiveTemplates: Record<
@@ -31,6 +32,7 @@ export const providerArchiveTemplates: Record<
 	gitlab: (repo, hash) => `${repo.url}/-/archive/${hash}/${repo.name}-${hash}.tar.gz`,
 	bitbucket: (repo, hash) => `${repo.url}/get/${hash}.tar.gz`,
 	'git.sr.ht': (repo, hash) => `${repo.url}/archive/${hash}.tar.gz`,
+	gist: (_repo, hash) => `https://codeload.github.com/gist/${_repo.name}/tar.gz/${hash}`,
 };
 
 function isGitProvider(site: string): site is GitProvider {
@@ -66,6 +68,12 @@ function resolveSource(source: string, src: string): ResolvedSource {
 	let isWebUrl = false;
 	let remainder = source;
 
+	if (source.startsWith('gist:'))
+		throw new DegitError(
+			'degit does not support the gist: shorthand; use a full URL or SSH address',
+			{ code: 'BAD_SRC' },
+		);
+
 	if (source.startsWith('https://') || source.startsWith('http://')) {
 		const parsed = new URL(source);
 		site = parsed.hostname.replace(/\.(com|org)$/u, '');
@@ -98,6 +106,8 @@ function resolveSource(source: string, src: string): ResolvedSource {
 			remainder = source.slice(colonIndex + 1);
 		}
 	}
+
+	if (site === 'gist.github' || site === 'gist.github.com') site = 'gist';
 
 	return { remainder, site, transport, isWebUrl };
 }
@@ -134,7 +144,40 @@ function parseWebPath(
 			if (i === -1) return undefined;
 			return { ref: segments[i + 1], subdir: segments.slice(i + 2) };
 		}
+		case 'gist': {
+			return undefined;
+		}
 	}
+}
+
+function parseGist(
+	src: string,
+	segments: string[],
+	refValue: string,
+	transport: Repo['transport'],
+): Repo {
+	const rawId = segments.length === 1 ? segments[0] : segments[1];
+
+	if (!rawId) throw new DegitError(`could not parse ${src}`, { code: 'BAD_SRC' });
+
+	const id = rawId.replace(/\.git$/u, '');
+	const user = segments.length === 1 ? 'gist' : segments[0];
+	const subdirParts = segments.slice(2);
+	const subdir = subdirParts.length > 0 ? `/${subdirParts.join('/')}` : undefined;
+	const url = `https://gist.github.com/${id}.git`;
+	const ssh = `ssh://git@gist.github.com/${id}.git`;
+
+	return {
+		mode: 'tar',
+		name: id,
+		ref: refValue,
+		site: 'gist',
+		ssh,
+		subdir,
+		transport,
+		url,
+		user,
+	};
 }
 
 export function parse(src: string): Repo {
@@ -146,12 +189,16 @@ export function parse(src: string): Repo {
 	);
 
 	if (!isGitProvider(site)) {
-		throw new DegitError(`degit supports GitHub, GitLab, Sourcehut and BitBucket`, {
+		throw new DegitError(`degit supports GitHub, GitLab, Sourcehut, BitBucket and Gist`, {
 			code: 'UNSUPPORTED_HOST',
 		});
 	}
 
-	const [user, rawName, ...rest] = remainder.split('/').filter(Boolean);
+	const segments = remainder.split('/').filter(Boolean);
+
+	if (site === 'gist') return parseGist(src, segments, refValue, transport);
+
+	const [user, rawName, ...rest] = segments;
 	if (!user || !rawName) {
 		throw new DegitError(`could not parse ${src}`, {
 			code: 'BAD_SRC',

--- a/test/integration/public.test.ts
+++ b/test/integration/public.test.ts
@@ -38,6 +38,11 @@ const publicRepos: IntegrationRepo[] = [
 		gitUrl: 'https://git.sr.ht/~showyourcode/public',
 		site: 'git.sr.ht',
 	},
+	{
+		expectedFile: 'README.md',
+		site: 'gist',
+		src: 'https://gist.github.com/mbostock/3883098',
+	},
 ];
 
 describe('public integration suite', () => {

--- a/test/unit/index-support.ts
+++ b/test/unit/index-support.ts
@@ -14,14 +14,15 @@ function createProviderCase({ build, domain, publicSrc, redirectUrl, site, user 
 	const name = 'degit-test-repo';
 	const privateName = `${name}-private`;
 	const url = `https://${domain}/${user}/${name}`;
+	const built = build({ domain, name, privateName, site, url, user });
 	return {
-		...build({ domain, name, privateName, site, url, user }),
+		...built,
 		name,
 		privateName,
 		publicSrc,
 		redirectUrl,
 		site,
-		url,
+		url: built.url ?? url,
 		user,
 	};
 }
@@ -101,6 +102,27 @@ export const providerCases = [
 			lsRemote: `git ls-remote -- ${url}`,
 			ssh: `ssh://git@${domain}/${user}/${name}`,
 		}),
+	}),
+	createProviderCase({
+		domain: 'gist.github.com',
+		publicSrc: 'https://gist.github.com/Rich-Harris/degit-test-repo',
+		redirectUrl: 'https://gist.github.com/forbidden',
+		site: 'gist',
+		user: 'Rich-Harris',
+		build: ({ name, site, user }) => {
+			const gistUrl = `https://gist.github.com/${name}.git`;
+			const gistSsh = `ssh://git@gist.github.com/${name}.git`;
+			return {
+				archiveRoot: `${name}-${refsHash}`,
+				archiveUrl: (hash) =>
+					providerArchiveTemplates[site as GitProvider]({ url: gistUrl, name }, hash),
+				gitSrc: `git@gist.github.com:${name}.git`,
+				lsRemote: `git ls-remote -- ${gistUrl}`,
+				ssh: gistSsh,
+				url: gistUrl,
+				user,
+			};
+		},
 	}),
 ];
 

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -67,6 +67,76 @@ describe('degit index', () => {
 			assert.equal(repo.transport, 'https');
 		});
 	});
+	it('parses a bare gist HTTPS URL with a placeholder user when the URL contains only a gist id', () => {
+		const { repo } = degit('https://gist.github.com/abc123def456');
+
+		assert.equal(repo.site, 'gist');
+		assert.equal(repo.user, 'gist');
+		assert.equal(repo.name, 'abc123def456');
+		assert.equal(repo.url, 'https://gist.github.com/abc123def456.git');
+		assert.equal(repo.ssh, 'ssh://git@gist.github.com/abc123def456.git');
+		assert.equal(repo.transport, 'https');
+	});
+	it('parses an owner-scoped gist HTTPS URL when the URL contains an owner and a gist id', () => {
+		const { repo } = degit('https://gist.github.com/owner/abc123def456');
+
+		assert.equal(repo.site, 'gist');
+		assert.equal(repo.user, 'owner');
+		assert.equal(repo.name, 'abc123def456');
+		assert.equal(repo.url, 'https://gist.github.com/abc123def456.git');
+		assert.equal(repo.ssh, 'ssh://git@gist.github.com/abc123def456.git');
+	});
+	it('strips the .git suffix from a gist URL and still builds an id-only endpoint when the bare URL ends with .git', () => {
+		const { repo } = degit('https://gist.github.com/abc123def456.git');
+
+		assert.equal(repo.name, 'abc123def456');
+		assert.equal(repo.url, 'https://gist.github.com/abc123def456.git');
+	});
+	it('strips the .git suffix from an owner-scoped gist URL when the owner URL ends with .git', () => {
+		const { repo } = degit('https://gist.github.com/owner/abc123def456.git');
+
+		assert.equal(repo.user, 'owner');
+		assert.equal(repo.name, 'abc123def456');
+		assert.equal(repo.url, 'https://gist.github.com/abc123def456.git');
+	});
+	it('parses an scp-like gist SSH URL when the source uses git@gist.github.com syntax', () => {
+		const { repo } = degit('git@gist.github.com:abc123def456.git');
+
+		assert.equal(repo.site, 'gist');
+		assert.equal(repo.user, 'gist');
+		assert.equal(repo.name, 'abc123def456');
+		assert.equal(repo.transport, 'ssh');
+		assert.equal(repo.ssh, 'ssh://git@gist.github.com/abc123def456.git');
+	});
+	it('parses an explicit ssh:// gist URL when the source uses ssh transport', () => {
+		const { repo } = degit('ssh://git@gist.github.com/abc123def456');
+
+		assert.equal(repo.site, 'gist');
+		assert.equal(repo.user, 'gist');
+		assert.equal(repo.name, 'abc123def456');
+		assert.equal(repo.transport, 'ssh');
+		assert.equal(repo.url, 'https://gist.github.com/abc123def456.git');
+		assert.equal(repo.ssh, 'ssh://git@gist.github.com/abc123def456.git');
+	});
+	it('preserves extra gist path segments as the subdirectory when the URL contains trailing segments', () => {
+		const { repo } = degit('https://gist.github.com/owner/abc123def456/extra');
+
+		assert.equal(repo.name, 'abc123def456');
+		assert.equal(repo.subdir, '/extra');
+		assert.equal(repo.url, 'https://gist.github.com/abc123def456.git');
+	});
+	it('throws BAD_SRC for the gist: shorthand when the source uses the gist: prefix', () => {
+		assert.throws(
+			() => degit('gist:abc123def456'),
+			(err: any) => err?.code === 'BAD_SRC',
+		);
+	});
+	it('throws BAD_SRC when the gist path is empty', () => {
+		assert.throws(
+			() => degit('https://gist.github.com/'),
+			(err: any) => err?.code === 'BAD_SRC',
+		);
+	});
 	it('parses gitlab:// prefix with custom domain when host is explicit', () => {
 		const repo = parse('gitlab://git.example.com/user/repo');
 


### PR DESCRIPTION
## Summary

**What**

Adds GitHub Gist as a first-class provider so `degit` can copy gists in both `tar` and `git` modes.

**Why**

Issue #21 requests support for GitHub Gists. Gists are git repositories and can be fetched through the same tar/git flow as other providers.

## Linked issues

Closes #21

## Changes

- Register `gist` as a provider in `src/domain/repo.ts` with the `gist.github.com` domain and a `codeload.github.com/gist/<id>/tar.gz/<ref>` archive template.
- Parse the six supported gist URL forms:
  - `https://gist.github.com/<id>`
  - `https://gist.github.com/<user>/<id>`
  - `https://gist.github.com/<id>.git`
  - `https://gist.github.com/<user>/<id>.git`
  - `git@gist.github.com:<id>.git`
  - `ssh://git@gist.github.com/<id>`
- Strip `.git` from the gist id and build id-only canonical `https://gist.github.com/<id>.git` / `ssh://git@gist.github.com/<id>.git` URLs.
- Use a `gist` placeholder user for bare ids, preserving the supplied user for `/<user>/<id>` URLs.
- Reject the `gist:<id>` shorthand with `BAD_SRC`.
- Add a `gist` case to `parseWebPath` and update the unsupported-host message.
- Add gist test cases to the data-driven provider suite and targeted parser tests.
- Add a pinned public gist to the integration suite.
- Update user-facing docs (`docs/USAGE.md`, `assets/help.md`, `docs/CHANGELOG.md`, `docs/ARCHITECTURE.md`, `skills/degit/SKILL.md`, `llms.txt`).
- Update `scripts/oxlint-repo-guidelines.js` `allowedDocs` to allow the planning docs kept in the repository root.

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`)
- [x] Manual / CLI check if user-facing behavior changed
- [x] CI passes

All automated checks pass: `bun run build`, `bun run test`, `bun run lint:ci`, `bun run typecheck`, `bun run format:ci`, `bun run duplicates:ci`, `bun run knip:ci`, `bun run audit`, and `bun run test:integration`.

`bun run perf` reports a regression, but the measured times are ~70 ms against a baseline of ~30 ms and appear to be environment noise rather than a change introduced by this PR (no hot paths were touched).

## Review notes

**Breaking changes** (or none)

None. Existing providers remain unchanged.

**Risks / rollout** (or none)

The gist tar archive endpoint (`codeload.github.com/gist/<id>/tar.gz/<hash>`) is not officially documented, but it is the same endpoint used by `hosted-git-info` and other degit-like tooling. If it becomes unreliable, the fallback is to switch to the per-gist `archive/<hash>.tar.gz` endpoint.

**Focus areas for reviewers** (optional)

- Gist URL parsing in `src/domain/repo.ts` (bare vs owner/id, `.git` stripping, subdirectory handling).
- Whether the `allowedDocs` update for the root planning docs is acceptable.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
