### PR TITLE
chore: ignore .agents/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ bun.lockb
 
 .vscode/settings.json
 .devin
+.agents/


### PR DESCRIPTION
## Summary

**What**

Adds `.agents/` to `.gitignore`.

**Why**

Agent-driven workflows often write working documents (plans, reviews, flow docs) under `.agents/`. Without an ignore entry, those files show up as untracked noise in every contributor clone.

## Linked issues

N/A

## Changes

- `.gitignore`: ignore the `.agents/` directory (alongside the existing `.devin` entry)

## Testing

- `git check-ignore -v .agents/flows/example.md` now matches the new rule
- No runtime or user-facing behavior changed

- [x] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed (N/A - no behavior change)
- [x] CI passes

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

None.

## Checklist

- [x] Error paths and exit codes considered where relevant (N/A)
- [x] Help text, completions, or docs updated if user-facing strings changed (N/A)
- [x] Squashed to a single commit
- [x] No unrelated drive-by changes
