### PR TITLE
chore(release): 3.10.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,8 @@
 # degit changelog
 
-## [Unreleased]
+## [3.10.0]
 
-- Add GitHub Gist support for HTTPS and SSH URL forms ([#21](https://github.com/Rich-Harris/degit/issues/21)).
+- Add GitHub Gist support: `gist:` shorthand, HTTPS and SSH URL forms ([#21](https://github.com/Rich-Harris/degit/issues/21)).
 
 ## [3.9.0]
 
@@ -253,6 +253,7 @@
 
 - First release
 
+[3.10.0]: https://github.com/Rich-Harris/degit/compare/v3.9.0...v3.10.0
 [3.9.0]: https://github.com/Rich-Harris/degit/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/Rich-Harris/degit/compare/v3.7.1...v3.8.0
 [3.7.1]: https://github.com/Rich-Harris/degit/compare/v3.7.0...v3.7.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "degit",
-	"version": "3.9.0",
+	"version": "3.10.0",
 	"description": "Straightforward project scaffolding",
 	"keywords": [
 		"git",


### PR DESCRIPTION
## Summary

**What**

Release prep for degit 3.10.0 (minor): version bump in `package.json` and a `[3.10.0]` section in `docs/CHANGELOG.md` with its compare link.

**Why**

Ship GitHub Gist support ([#489](https://github.com/Rich-Harris/degit/pull/489), closes [#21](https://github.com/Rich-Harris/degit/issues/21)). After merge, pushing tag `v3.10.0` on the merge commit triggers the release and npm publish workflows.

## Linked issues

## Changes

- `package.json`: 3.9.0 -> 3.10.0
- `docs/CHANGELOG.md`: `[Unreleased]` -> `[3.10.0]`; entry now also mentions the `gist:` shorthand alongside the HTTPS/SSH URL forms (both shipped in #489); added the `[3.10.0]` compare link at the bottom

## Testing

How you verified this (commands, scenarios, or N/A):

- [ ] Automated tests (`bun run test`)
- [ ] Manual / CLI check if user-facing behavior changed
- [x] CI passes

N/A - metadata/docs only, no code changes.

## Review notes

**Breaking changes** (or none)

None.

**Risks / rollout** (or none)

None. Tag `v3.10.0` only after this lands on master.

**Focus areas for reviewers** (optional)

The changelog entry wording change vs. what was merged in #489.

## Checklist

- [x] Error paths and exit codes considered where relevant
- [x] Help text, completions, or docs updated if user-facing strings changed
- [ ] Squashed to a single commit
- [x] No unrelated drive-by changes