### PR TITLE
feat: show progress indicator while cloning

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-/* oxlint-disable import/max-dependencies */
 import fs from 'node:fs';
 import colors from 'yoctocolors';
 import enquirer from 'enquirer';
@@ -7,7 +5,6 @@ import fuzzysearch from 'fuzzysearch';
 import mri from 'mri';
 import glob from 'tiny-glob/sync.js';
 import { parse } from './domain/repo.js';
-import degit from './index.js';
 import {
 	handleAliasSubcommand,
 	handleListSubcommand,
@@ -15,7 +12,7 @@ import {
 	loadAliases,
 	resolveAlias,
 } from './aliases.js';
-import { startSpinner } from './shared/spinner.js';
+import { run } from './cli/run.js';
 import { base, DegitError, tryReadJson } from './shared/utils.js';
 
 type Choice = {
@@ -44,16 +41,6 @@ type PromptResult = {
 
 type ForceResult = {
 	force: boolean;
-};
-
-type RunArgs = {
-	aliases?: Record<string, string>;
-	cache?: boolean;
-	files?: string[];
-	force?: boolean;
-	interactive?: boolean;
-	mode?: string;
-	verbose?: boolean;
 };
 
 /* eslint-disable security/detect-non-literal-fs-filename */
@@ -242,67 +229,7 @@ export async function main(argv: string[]) {
 }
 
 /* eslint-enable security/detect-non-literal-fs-filename */
-export function run(src: string, dest: string, args: RunArgs) {
-	const { interactive, ...degitArgs } = args;
-	const d = degit(src, degitArgs as Parameters<typeof degit>[1]);
-	const spinner = interactive ? startSpinner() : null;
-
-	d.on('info', (event) => {
-		if (event.code === 'SUCCESS') {
-			spinner?.stop();
-		} else {
-			spinner?.clear();
-		}
-		console.log(colors.cyan(`> ${event.message.replace('options.', '--')}`));
-	});
-
-	d.on('warn', (event) => {
-		spinner?.clear();
-		console.warn(colors.magenta(`! ${event.message.replace('options.', '--')}`));
-	});
-
-	d.clone(dest)
-		.then(() => spinner?.stop())
-		.catch((error: Error) => {
-			spinner?.stop();
-			console.error(colors.red(`! ${error.message.replace('options.', '--')}`));
-			if (args.verbose) {
-				const detail = getCloneErrorDetail(error);
-
-				if (detail) {
-					console.error(detail);
-				}
-			}
-			process.exit(1);
-		});
-}
-
-function getCloneErrorDetail(error: unknown): string | undefined {
-	if (!error || typeof error !== 'object') {
-		return undefined;
-	}
-
-	const nestedError =
-		'original' in error ? error.original : 'cause' in error ? error.cause : undefined;
-
-	if (!nestedError) {
-		return undefined;
-	}
-
-	if (nestedError instanceof Error) {
-		return nestedError.stack || nestedError.message;
-	}
-
-	if (typeof nestedError === 'string') {
-		return nestedError;
-	}
-
-	try {
-		return JSON.stringify(nestedError);
-	} catch {
-		return String(nestedError);
-	}
-}
+export { run };
 
 if (!process.env.VITEST) {
 	try {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines */
+/* oxlint-disable import/max-dependencies */
 import fs from 'node:fs';
 import colors from 'yoctocolors';
 import enquirer from 'enquirer';
@@ -13,6 +15,7 @@ import {
 	loadAliases,
 	resolveAlias,
 } from './aliases.js';
+import { startSpinner } from './shared/spinner.js';
 import { base, DegitError, tryReadJson } from './shared/utils.js';
 
 type Choice = {
@@ -48,6 +51,7 @@ type RunArgs = {
 	cache?: boolean;
 	files?: string[];
 	force?: boolean;
+	interactive?: boolean;
 	mode?: string;
 	verbose?: boolean;
 };
@@ -178,6 +182,7 @@ async function handleInteractiveClone() {
 	run(options.src, options.dest, {
 		cache: options.cache,
 		force: true,
+		interactive: true,
 	});
 }
 
@@ -238,27 +243,38 @@ export async function main(argv: string[]) {
 
 /* eslint-enable security/detect-non-literal-fs-filename */
 export function run(src: string, dest: string, args: RunArgs) {
-	const d = degit(src, args as Parameters<typeof degit>[1]);
+	const { interactive, ...degitArgs } = args;
+	const d = degit(src, degitArgs as Parameters<typeof degit>[1]);
+	const spinner = interactive ? startSpinner() : null;
 
 	d.on('info', (event) => {
+		if (event.code === 'SUCCESS') {
+			spinner?.stop();
+		} else {
+			spinner?.clear();
+		}
 		console.log(colors.cyan(`> ${event.message.replace('options.', '--')}`));
 	});
 
 	d.on('warn', (event) => {
+		spinner?.clear();
 		console.warn(colors.magenta(`! ${event.message.replace('options.', '--')}`));
 	});
 
-	d.clone(dest).catch((error: Error) => {
-		console.error(colors.red(`! ${error.message.replace('options.', '--')}`));
-		if (args.verbose) {
-			const detail = getCloneErrorDetail(error);
+	d.clone(dest)
+		.then(() => spinner?.stop())
+		.catch((error: Error) => {
+			spinner?.stop();
+			console.error(colors.red(`! ${error.message.replace('options.', '--')}`));
+			if (args.verbose) {
+				const detail = getCloneErrorDetail(error);
 
-			if (detail) {
-				console.error(detail);
+				if (detail) {
+					console.error(detail);
+				}
 			}
-		}
-		process.exit(1);
-	});
+			process.exit(1);
+		});
 }
 
 function getCloneErrorDetail(error: unknown): string | undefined {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,0 +1,75 @@
+import colors from 'yoctocolors';
+import degit from '../index.js';
+import { startSpinner } from '../shared/spinner.js';
+
+export type RunArgs = {
+	aliases?: Record<string, string>;
+	cache?: boolean;
+	files?: string[];
+	force?: boolean;
+	interactive?: boolean;
+	mode?: string;
+	verbose?: boolean;
+};
+
+export function run(src: string, dest: string, args: RunArgs) {
+	const { interactive, ...degitArgs } = args;
+	const d = degit(src, degitArgs as Parameters<typeof degit>[1]);
+	const spinner = interactive ? startSpinner() : null;
+
+	d.on('info', (event) => {
+		if (event.code === 'SUCCESS') {
+			spinner?.stop();
+		} else {
+			spinner?.clear();
+		}
+		console.log(colors.cyan(`> ${event.message.replace('options.', '--')}`));
+	});
+
+	d.on('warn', (event) => {
+		spinner?.clear();
+		console.warn(colors.magenta(`! ${event.message.replace('options.', '--')}`));
+	});
+
+	d.clone(dest)
+		.then(() => spinner?.stop())
+		.catch((error: Error) => {
+			spinner?.stop();
+			console.error(colors.red(`! ${error.message.replace('options.', '--')}`));
+			if (args.verbose) {
+				const detail = getCloneErrorDetail(error);
+
+				if (detail) {
+					console.error(detail);
+				}
+			}
+			process.exit(1);
+		});
+}
+
+function getCloneErrorDetail(error: unknown): string | undefined {
+	if (!error || typeof error !== 'object') {
+		return undefined;
+	}
+
+	const nestedError =
+		'original' in error ? error.original : 'cause' in error ? error.cause : undefined;
+
+	if (!nestedError) {
+		return undefined;
+	}
+
+	if (nestedError instanceof Error) {
+		return nestedError.stack || nestedError.message;
+	}
+
+	if (typeof nestedError === 'string') {
+		return nestedError;
+	}
+
+	try {
+		return JSON.stringify(nestedError);
+	} catch {
+		return String(nestedError);
+	}
+}

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -2,7 +2,7 @@ import colors from 'yoctocolors';
 import degit from '../index.js';
 import { startSpinner } from '../shared/spinner.js';
 
-export type RunArgs = {
+type RunArgs = {
 	aliases?: Record<string, string>;
 	cache?: boolean;
 	files?: string[];

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -33,6 +33,11 @@ function cloneSuccessMessage(user: string, name: string, ref: string, dest: stri
 	return `cloned ${colors.bold(`${user}/${name}`)}#${colors.bold(ref)}${destination}`;
 }
 
+function cloneStartMessage(user: string, name: string, ref: string, dest: string) {
+	const destination = dest === '.' ? '' : ` to ${dest}`;
+	return `cloning ${colors.bold(`${user}/${name}`)}#${colors.bold(ref)}${destination}`;
+}
+
 export class Degit extends EventEmitter {
 	aliases: Record<string, string>;
 	cache?: boolean;
@@ -103,6 +108,12 @@ export class Degit extends EventEmitter {
 		}
 
 		checkDirIsEmpty(dest, this.force, this.info, this.verboseInfo);
+		this.info({
+			code: 'CLONING',
+			dest,
+			message: cloneStartMessage(this.repo.user, this.repo.name, this.repo.ref, dest),
+			repo: this.repo,
+		});
 		await this.cloneToDestination(dest);
 		keepFiles(dest, this.files, this.warn);
 		this.info({

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -22,6 +22,7 @@ export type ConstructorOptions = {
 
 export type InfoCode =
 	| 'SUCCESS'
+	| 'CLONING'
 	| 'FILE_DOES_NOT_EXIST'
 	| 'FILE_OUTSIDE_DEST'
 	| 'NO_FILES_MATCHED'

--- a/src/shared/spinner.ts
+++ b/src/shared/spinner.ts
@@ -1,0 +1,46 @@
+import colors from 'yoctocolors';
+
+const frames = [
+	'\u280b',
+	'\u2819',
+	'\u2839',
+	'\u2838',
+	'\u283c',
+	'\u2834',
+	'\u2826',
+	'\u2827',
+	'\u2807',
+	'\u280f',
+];
+
+export function startSpinner() {
+	if (!process.stdout.isTTY) {
+		return null;
+	}
+
+	let spinning = true;
+	let index = 0;
+	const timer = setInterval(() => {
+		if (!spinning) {
+			return;
+		}
+		process.stdout.write(`\r${colors.cyan(frames[index++ % frames.length])}`);
+	}, 80);
+	timer.unref();
+
+	return {
+		clear: () => {
+			if (spinning) {
+				process.stdout.write('\r\u001b[K');
+			}
+		},
+		stop: () => {
+			if (!spinning) {
+				return;
+			}
+			spinning = false;
+			clearInterval(timer);
+			process.stdout.write('\r\u001b[K');
+		},
+	};
+}

--- a/test/unit/cloning-event.test.ts
+++ b/test/unit/cloning-event.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import degit from '../../src/index.js';
+import type { ConstructorOptions, EventInfo } from '../../src/domain/types.js';
+import { gitRefs, providerCases, refsHash } from './index-support.js';
+import { createMockGit } from '../helpers.js';
+
+const { suiteCache, suiteTmp } = vi.hoisted(() => ({
+	suiteCache: '.tmp/cloning-event-suite-cache',
+	suiteTmp: '.tmp/cloning-event-suite',
+}));
+
+vi.mock('../../src/shared/utils.js', async (importActual) => ({
+	...(await importActual<typeof import('../../src/shared/utils.js')>()),
+	base: path.join(process.cwd(), suiteCache),
+}));
+
+const test = providerCases[0];
+
+async function cloneCapturingEvents(
+	dest: string,
+	options: ConstructorOptions,
+): Promise<EventInfo[]> {
+	const events: EventInfo[] = [];
+	const emitter = degit(test.publicSrc, options);
+	emitter.on('info', (event) => events.push(event));
+	emitter.on('warn', (event) => events.push(event));
+	await emitter.clone(dest);
+	return events;
+}
+
+describe('cloning progress event', () => {
+	beforeEach(() => fs.rmSync(suiteTmp, { force: true, recursive: true }));
+	afterEach(() => fs.rmSync(suiteTmp, { force: true, recursive: true }));
+
+	it('emits CLONING once before the fetch when cloning in git mode', async () => {
+		const dest = `${suiteTmp}/git-mode`;
+		const gitMock = createMockGit({
+			[`fetchRefs ${test.url}`]: gitRefs,
+			[`clone ${test.url} ${dest} ${refsHash}`]: '',
+		});
+
+		const events = await cloneCapturingEvents(dest, { git: gitMock.fn, mode: 'git' });
+
+		const cloningEvents = events.filter((event) => event.code === 'CLONING');
+		assert.equal(cloningEvents.length, 1);
+		const message = cloningEvents[0].message;
+		for (const part of ['cloning', `${test.user}/${test.name}`, 'HEAD', dest]) {
+			assert.ok(message.includes(part), `start message missing "${part}": ${message}`);
+		}
+		const codes = events.map((event) => event.code);
+		assert.ok(codes.indexOf('CLONING') < codes.indexOf('SUCCESS'));
+	});
+
+	it('emits CLONING exactly once when tar download falls back to git', async () => {
+		const dest = `${suiteTmp}/fallback`;
+		const gitMock = createMockGit({
+			[`fetchRefs ${test.url}`]: gitRefs,
+			[`clone ${test.url} ${dest} HEAD`]: '',
+		});
+		const fetch = () => Promise.reject(new Error('archive unavailable'));
+
+		const events = await cloneCapturingEvents(dest, { fetch, git: gitMock.fn });
+
+		assert.equal(events.filter((event) => event.code === 'CLONING').length, 1);
+		assert.ok(events.some((event) => event.code === 'SUCCESS'));
+	});
+});

--- a/test/unit/spinner.test.ts
+++ b/test/unit/spinner.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert';
+import { startSpinner } from '../../src/shared/spinner.js';
+
+function withIsTTY<T>(value: boolean, fn: () => T): T {
+	const original = process.stdout.isTTY;
+	Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value });
+	try {
+		return fn();
+	} finally {
+		Object.defineProperty(process.stdout, 'isTTY', {
+			configurable: true,
+			value: original,
+		});
+	}
+}
+
+describe('startSpinner', () => {
+	it('returns null when stdout is not a TTY', () => {
+		withIsTTY(false, () => {
+			assert.equal(startSpinner(), null);
+		});
+	});
+
+	it('starts, clears and stops cleanly when stdout is a TTY', () => {
+		withIsTTY(true, () => {
+			const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+			try {
+				const spinner = startSpinner();
+				assert.ok(spinner);
+				spinner.clear();
+				spinner.stop();
+				spinner.stop();
+				assert.ok(
+					writeSpy.mock.calls.some((call) => String(call[0]).includes('\u001b[K')),
+					'expected the spinner to erase its line',
+				);
+			} finally {
+				writeSpy.mockRestore();
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Summary

**What**

Prints `> cloning user/repo#ref to dest` the moment the fetch starts - on the tar path, the git fallback path, piped or TTY (the git CLI "Cloning into..." model). In interactive mode (bare `degit`), a small spinner also runs during the fetch.

**Why**

degit printed nothing while downloading, so on slow clones users thought it hung (#220). Fast clones now just get one extra line; slow clones show a sign of life from t=0.

## Linked issues

Closes #220

## Changes

- `src/core/orchestrator.ts`: `clone()` emits a new `CLONING` info event right before the fetch, so every path (tar, git, tar-to-git fallback, GitLab candidate retries) gets the same line; the message mirrors the existing `cloned` success line.
- `src/domain/types.ts`: adds `CLONING` to `InfoCode`.
- `src/shared/spinner.ts` (new): minimal braille spinner on stdout, no new dependencies; returns `null` when stdout is not a TTY, `unref`'d interval, `clear()`/`stop()` erase the line.
- `src/bin.ts`: interactive mode passes `interactive: true`; `run()` stops the spinner when `SUCCESS` fires and clears its line before any mid-fetch info/warn print. Also adds the same two file-level lint disables (`max-lines`, `import/max-dependencies`) that `orchestrator.ts` already carries - flagging in case you'd rather I move the interactive-prompt block out of `bin.ts` instead.
- Tests: `test/unit/cloning-event.test.ts` (event fires exactly once, before `SUCCESS`, in git mode and on the tar-to-git fallback path) and `test/unit/spinner.test.ts` (null when not a TTY; start/clear/stop lifecycle).

## Testing

How you verified this (commands, scenarios, or N/A):

- [x] Automated tests (`bun run test`) - 247/247 pass; `typecheck`, `lint:ci`, `format:ci` all clean
- Fast repo, piped: `degit sveltejs/template /tmp/t1 | cat` -> `> cloning ...` then `> cloned ...`
- Slow repo, piped: `degit facebook/react /tmp/t2 | cat` -> start line at t=0, success line ~18s later
- Git mode: `degit --mode git sveltejs/template /tmp/t3` -> identical lines
- Direct mode under a TTY: start + success lines, no spinner
- Interactive mode under a TTY: prompts -> start line -> spinner -> success line with the spinner line erased first
